### PR TITLE
force files to be trashed

### DIFF
--- a/src/apps/fuse/callbacks/MakeDirectoryCallback.ts
+++ b/src/apps/fuse/callbacks/MakeDirectoryCallback.ts
@@ -8,6 +8,10 @@ export class MakeDirectoryCallback extends NotifyFuseCallback {
   }
 
   async execute(path: string, _mode: number) {
+    if (path.startsWith('/.Trash')) {
+      return this.right();
+    }
+
     try {
       await this.container.syncFolderMessenger.creating(path);
 

--- a/src/apps/fuse/callbacks/RenameMoveOrTrashFolder.ts
+++ b/src/apps/fuse/callbacks/RenameMoveOrTrashFolder.ts
@@ -4,14 +4,39 @@ import { VirtualDriveDependencyContainer } from '../dependency-injection/virtual
 import { FuseError, FuseUnknownError } from './FuseErrors';
 import { Either, left, right } from '../../../context/shared/domain/Either';
 import { FolderStatuses } from '../../../context/virtual-drive/folders/domain/FolderStatus';
+import { Folder } from '../../../context/virtual-drive/folders/domain/Folder';
+import { DriveDesktopError } from '../../../context/shared/domain/errors/DriveDesktopError';
+import { SyncErrorCause } from '../../../shared/issues/SyncErrorCause';
 
 type RenameOrMoveRight = 'no-op' | 'success';
 
-export class RenameOrMoveFolder {
+export class RenameMoveOrTrashFolder {
   private static readonly NO_OP: RenameOrMoveRight = 'no-op';
   private static readonly SUCCESS: RenameOrMoveRight = 'success';
 
   constructor(private readonly container: VirtualDriveDependencyContainer) {}
+
+  private async trash(folder: Folder): Promise<FuseError | undefined> {
+    try {
+      await this.container.folderDeleter.run(folder.uuid);
+      return undefined;
+    } catch (trowed: unknown) {
+      const cause: SyncErrorCause =
+        trowed instanceof DriveDesktopError ? trowed.syncErrorCause : 'UNKNOWN';
+
+      await this.container.syncFileMessenger.issues({
+        error: 'DELETE_ERROR',
+        cause,
+        name: folder.name,
+      });
+
+      if (trowed instanceof FuseError) {
+        return trowed;
+      }
+
+      return new FuseUnknownError();
+    }
+  }
 
   async execute(
     src: string,
@@ -23,7 +48,17 @@ export class RenameOrMoveFolder {
     });
 
     if (!folder) {
-      return right(RenameOrMoveFolder.NO_OP);
+      return right(RenameMoveOrTrashFolder.NO_OP);
+    }
+
+    if (dest.startsWith('/.Trash')) {
+      const error = await this.trash(folder);
+
+      if (!error) {
+        return right(RenameMoveOrTrashFolder.SUCCESS);
+      }
+
+      return left(error);
     }
 
     try {
@@ -41,7 +76,7 @@ export class RenameOrMoveFolder {
         desiredPath.name()
       );
 
-      return right(RenameOrMoveFolder.SUCCESS);
+      return right(RenameMoveOrTrashFolder.SUCCESS);
     } catch (throwed: unknown) {
       await this.container.syncFolderMessenger.issue({
         error: 'FOLDER_RENAME_ERROR',

--- a/src/apps/fuse/callbacks/RenameOrMoveCallback.ts
+++ b/src/apps/fuse/callbacks/RenameOrMoveCallback.ts
@@ -2,23 +2,23 @@ import { OfflineDriveDependencyContainer } from '../dependency-injection/offline
 import { VirtualDriveDependencyContainer } from '../dependency-injection/virtual-drive/VirtualDriveDependencyContainer';
 import { NotifyFuseCallback } from './FuseCallback';
 import { FuseNoSuchFileOrDirectoryError } from './FuseErrors';
-import { RenameOrMoveFile } from './RenameOrMoveFile';
-import { RenameOrMoveFolder } from './RenameOrMoveFolder';
+import { RenameMoveOrTrashFile } from './RenameMoveOrTrashFile';
+import { RenameMoveOrTrashFolder } from './RenameMoveOrTrashFolder';
 import { UploadOnRename } from './UploadOnRename';
 
 export class RenameOrMoveCallback extends NotifyFuseCallback {
-  private readonly updateFile: RenameOrMoveFile;
-  private readonly updateFolder: RenameOrMoveFolder;
+  private readonly updateFile: RenameMoveOrTrashFile;
+  private readonly updateFolder: RenameMoveOrTrashFolder;
   private readonly uploadOnRename: UploadOnRename;
 
   constructor(
     virtual: VirtualDriveDependencyContainer,
     offline: OfflineDriveDependencyContainer
   ) {
-    super('Rename Or Move', { input: true, output: true });
+    super('Rename Move or Trash', { input: true, output: true });
 
-    this.updateFile = new RenameOrMoveFile(virtual);
-    this.updateFolder = new RenameOrMoveFolder(virtual);
+    this.updateFile = new RenameMoveOrTrashFile(virtual);
+    this.updateFolder = new RenameMoveOrTrashFolder(virtual);
     this.uploadOnRename = new UploadOnRename(offline, virtual);
   }
 


### PR DESCRIPTION
After we allowed files to be uploaded on a path update the modify path callback was called instead of the delete one moving the files to a.Trash folder.

This avoid creating a .Trash folder and forces items to be deleted