### PR TITLE
[PB-2224] fix: malicious path false positive

### DIFF
--- a/src/context/shared/domain/value-objects/Path.ts
+++ b/src/context/shared/domain/value-objects/Path.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { InvalidArgumentError } from '../errors/InvalidArgumentError';
 import { ValueObject } from './ValueObject';
 
-const isWindowsRootDirectory = /[a-zA-Z]:[\\/]/;
+const isWindowsRootDirectory = /^[a-zA-Z]:[\\/]/;
 const containsNullCharacter = /\0/g;
 
 export abstract class Path extends ValueObject<string> {

--- a/tests/context/shared/domain/Path.test.ts
+++ b/tests/context/shared/domain/Path.test.ts
@@ -1,0 +1,15 @@
+import { Path } from '../../../../src/context/shared/domain/value-objects/Path';
+
+class PathTest extends Path {}
+
+describe('Path', () => {
+  it('does not mark a path with ":" in the middle as malicious', () => {
+    const path = '/My Folder:/file.txt';
+
+    try {
+      new PathTest(path);
+    } catch (err) {
+      expect(err).not.toBeDefined();
+    }
+  });
+});


### PR DESCRIPTION
#### Issue
On Linux paths with colons are possible. A path like `/folder:/file.txt` is currently marked as malicious.

#### Fix
Check for the Windows drive pattern only at the beginning of the path