### PR TITLE
[PB-3461]: fix/dark mode backups

### DIFF
--- a/src/apps/renderer/pages/Settings/Backups/Selector/BackupFolderSelector.tsx
+++ b/src/apps/renderer/pages/Settings/Backups/Selector/BackupFolderSelector.tsx
@@ -16,17 +16,18 @@ export default function BackupFolderSelector({
 }: BackupFolderSelectorProps) {
   const { translate } = useTranslationContext();
 
-  const { backups, backupsState, addBackup, disableBackup } = useContext(BackupContext);
+  const { backups, backupsState, addBackup, disableBackup } =
+    useContext(BackupContext);
 
   const [selectedBackup, setSelectedBackup] = useState<BackupInfo | null>(null);
 
   return (
-    <div className="flex flex-col gap-3 p-4">
+    <div className="flex flex-col gap-3 bg-surface p-4 text-highlight dark:bg-gray-1 dark:text-gray-100">
       <div className="flex">
         <h1 className="text-lg font-normal">
           {translate('settings.backups.title')}
         </h1>
-        <div className="ml-auto text-gray-50">
+        <div className="ml-auto text-gray-50 dark:text-gray-80">
           {backupsState === 'SUCCESS' &&
             translate('settings.backups.selected-folder', {
               count: backups.length,
@@ -34,7 +35,7 @@ export default function BackupFolderSelector({
         </div>
       </div>
       <div
-        className="border-l-neutral-30  h-44 overflow-y-auto rounded-lg border border-gray-20 bg-white"
+        className="border-l-neutral-30 h-44 overflow-y-auto rounded-lg border border-gray-20 bg-white dark:bg-gray-10"
         onClick={() => setSelectedBackup(null)}
         role="none"
       >
@@ -48,7 +49,7 @@ export default function BackupFolderSelector({
           <LoadingFolders state={backupsState} />
         )}
       </div>
-      <div className=" flex items-center justify-between">
+      <div className="flex items-center justify-between">
         <div className="flex">
           <Button
             onClick={addBackup}

--- a/src/apps/renderer/pages/Settings/Backups/Selector/BackupsList.tsx
+++ b/src/apps/renderer/pages/Settings/Backups/Selector/BackupsList.tsx
@@ -28,8 +28,8 @@ export function BackupsList({
             selected?.folderId === backup.folderId
               ? 'bg-primary text-white'
               : index % 2 !== 0
-              ? 'text-neutral-700 bg-white'
-              : 'bg-l-neutral-10 text-neutral-700'
+              ? 'bg-alternate-1 dark:bg-alternate-1 text-highlight dark:text-gray-100'
+              : 'bg-alternate-2 dark:bg-alternate-2 text-highlight dark:text-gray-100'
           }`}
         >
           <BackupListItem


### PR DESCRIPTION
The backup screens did not support dark mode, causing white text to be over a white background. 