### PR TITLE
[PB-2604]: fix/ignore empty files in batch processing and grouping 

### DIFF
--- a/src/apps/backups/batches/AddedFilesBatchCreator.ts
+++ b/src/apps/backups/batches/AddedFilesBatchCreator.ts
@@ -3,12 +3,13 @@ import { GroupFilesInChunksBySize } from './GroupFilesInChunksBySize';
 import { LocalFile } from '../../../context/local/localFile/domain/LocalFile';
 
 export class AddedFilesBatchCreator {
-  private static readonly sizes = ['small', 'medium', 'big'] as const;
+  private static readonly sizes = ['empty', 'small', 'medium', 'big'] as const;
 
   static run(files: Array<LocalFile>): Array<Array<LocalFile>> {
-    const batches = AddedFilesBatchCreator.sizes.flatMap((size) => {
-      const groupedBySize = GroupFilesBySize[size](files);
+    const nonEmptyFiles = files.filter((f) => f.size > 0);
 
+    const batches = AddedFilesBatchCreator.sizes.flatMap((size) => {
+      const groupedBySize = GroupFilesBySize[size](nonEmptyFiles);
       return GroupFilesInChunksBySize[size](groupedBySize);
     });
 

--- a/src/apps/backups/batches/GroupFilesBySize.ts
+++ b/src/apps/backups/batches/GroupFilesBySize.ts
@@ -1,6 +1,10 @@
 import { LocalFile } from '../../../context/local/localFile/domain/LocalFile';
 
 export class GroupFilesBySize {
+  static empty(files: Array<LocalFile>) {
+    return files.filter((file) => file.isEmpty());
+  }
+
   static small(files: Array<LocalFile>) {
     return files.filter((file) => file.isSmall());
   }

--- a/src/apps/backups/batches/GroupFilesInChunksBySize.ts
+++ b/src/apps/backups/batches/GroupFilesInChunksBySize.ts
@@ -31,6 +31,10 @@ export class GroupFilesInChunksBySize {
     );
   }
 
+  static empty(all: Array<LocalFile>): Chucks {
+    return GroupFilesInChunksBySize.chunk(all, 1);
+  }
+
   private static chunk(files: Array<LocalFile>, size: number) {
     return _.chunk(files, size);
   }

--- a/src/context/local/localFile/domain/LocalFile.ts
+++ b/src/context/local/localFile/domain/LocalFile.ts
@@ -34,6 +34,10 @@ export class LocalFile extends AggregateRoot {
     return this._path.endsWith(otherPath);
   }
 
+  isEmpty(): boolean {
+    return this._size.isEmpty();
+  }
+
   isSmall(): boolean {
     return this._size.isSmall();
   }

--- a/src/context/local/localFile/domain/LocalFileSize.ts
+++ b/src/context/local/localFile/domain/LocalFileSize.ts
@@ -11,9 +11,13 @@ export class LocalFileSize extends ValueObject<number> {
   }
 
   private validate(value: number) {
-    if (value <= 0) {
+    if (value < 0) {
       throw new Error(`A remote file size cannot have value ${value}`);
     }
+  }
+
+  isEmpty(): boolean {
+    return this.value === 0;
   }
 
   isSmall(): boolean {

--- a/tests/context/local/localFile/domain/LocalFileSizeMother.ts
+++ b/tests/context/local/localFile/domain/LocalFileSizeMother.ts
@@ -1,6 +1,9 @@
 import { LocalFileSize } from '../../../../../src/context/local/localFile/domain/LocalFileSize';
 
 export class LocalFileSizeMother {
+  static empty(): LocalFileSize {
+    return new LocalFileSize(0);
+  }
   static small(): LocalFileSize {
     return new LocalFileSize(LocalFileSize.MAX_SMALL_FILE_SIZE);
   }


### PR DESCRIPTION
The presence of an empty file (size 0) during backup used to cause the entire backup to fail with "UNKNOWN ERROR". In this PR empty files are simply ignored during backup.