### PR TITLE
[PB-3453]: fix/ambiguous io error

### DIFF
--- a/src/apps/drive/fuse/callbacks/FuseCodes.ts
+++ b/src/apps/drive/fuse/callbacks/FuseCodes.ts
@@ -19,4 +19,7 @@ export enum FuseCodes {
 
   // Permission denied
   EACCES = fuse.EACCES,
+
+  // Network is down
+  ENETDOWN = fuse.ENETDOWN,
 }

--- a/src/apps/drive/fuse/callbacks/FuseErrors.ts
+++ b/src/apps/drive/fuse/callbacks/FuseErrors.ts
@@ -2,46 +2,53 @@ import { FuseCodes } from './FuseCodes';
 
 export class FuseError extends Error {
   public readonly code: number;
+  public readonly timestamp: Date;
 
   constructor(code: FuseCodes, message: string) {
     super(message);
-
     this.code = code;
+    this.timestamp = new Date();
   }
 }
 
 export class FuseNoSuchFileOrDirectoryError extends FuseError {
   constructor(readonly path: string) {
-    super(FuseCodes.ENOENT, `No such file or directory <${path}>`);
+    super(FuseCodes.ENOENT, `No such file or directory: <${path}>`);
   }
 }
 
 export class FuseFileOrDirectoryAlreadyExistsError extends FuseError {
   constructor() {
-    super(FuseCodes.EEXIST, 'File or directory already exists');
+    super(FuseCodes.EEXIST, 'File or directory already exists.');
   }
 }
 
 export class FuseIOError extends FuseError {
-  constructor() {
-    super(FuseCodes.EIO, 'Input/output error');
+  constructor(details?: string) {
+    super(FuseCodes.EIO, `Input/output error${details ? `: ${details}` : ''}.`);
   }
 }
 
 export class FuseInvalidArgumentError extends FuseError {
-  constructor() {
-    super(FuseCodes.EINVAL, 'Invalid argument');
+  constructor(argumentName: string) {
+    super(FuseCodes.EINVAL, `Invalid argument: ${argumentName}.`);
   }
 }
 
 export class FusePermissionDeniedError extends FuseError {
   constructor() {
-    super(FuseCodes.EACCES, 'Permission denied');
+    super(FuseCodes.EACCES, 'Permission denied.');
   }
 }
 
 export class FuseUnknownError extends FuseError {
+  constructor(details?: string) {
+    super(FuseCodes.EIO, `Unknown error${details ? `: ${details}` : ''}.`);
+  }
+}
+
+export class FuseNetworkError extends FuseError {
   constructor() {
-    super(FuseCodes.EIO, 'Unknown error');
+    super(FuseCodes.ENETDOWN, 'Network is down.');
   }
 }

--- a/src/apps/drive/fuse/callbacks/ReleaseCallback.ts
+++ b/src/apps/drive/fuse/callbacks/ReleaseCallback.ts
@@ -6,6 +6,7 @@ import { NotifyFuseCallback } from './FuseCallback';
 import { FuseIOError } from './FuseErrors';
 import Logger from 'electron-log';
 import { StorageCacheDeleter } from '../../../../context/storage/StorageFiles/application/delete/StorageCacheDeleter';
+import { TemporalFileDeleter } from '../../../../context/storage/TemporalFiles/application/deletion/TemporalFileDeleter';
 
 export class ReleaseCallback extends NotifyFuseCallback {
   constructor(private readonly container: Container) {
@@ -14,48 +15,62 @@ export class ReleaseCallback extends NotifyFuseCallback {
 
   async execute(path: string, _fd: number) {
     try {
-      const document = await this.container
-        .get(TemporalFileByPathFinder)
-        .run(path);
-
+      const document = await this.findDocument(path);
       if (document) {
-        this.logDebugMessage('Offline File found');
-        if (document.size.value === 0) {
-          this.logDebugMessage('File Size is 0');
-          return this.right();
-        }
-
-        if (document.isAuxiliary()) {
-          this.logDebugMessage('Offline File is Auxiliary');
-          return this.right();
-        }
-
-        await this.container.get(TemporalFileUploader).run(document.path.value);
-        this.logDebugMessage('File has been uploaded');
-        return this.right();
+        return await this.handleDocument(document, path);
       }
 
-      const virtualFile = await this.container.get(FirstsFileSearcher).run({
-        path,
-      });
-
+      const virtualFile = await this.findVirtualFile(path);
       if (virtualFile) {
-        await this.container
-          .get(StorageCacheDeleter)
-          .run(virtualFile.contentsId);
-
-        this.logDebugMessage(
-          `${virtualFile.path} removed from local file cache`
-        );
-
-        return this.right();
+        return await this.handleVirtualFile(virtualFile);
       }
 
       this.logDebugMessage(`File with ${path} not found`);
       return this.right();
     } catch (err: unknown) {
       Logger.error(err);
-      return this.left(new FuseIOError());
+      return this.left(
+        new FuseIOError('An unexpected error occurred during file release.')
+      );
     }
+  }
+
+  private async findDocument(path: string) {
+    return this.container.get(TemporalFileByPathFinder).run(path);
+  }
+
+  private async handleDocument(document: any, path: string) {
+    this.logDebugMessage('Offline File found');
+    if (document.size.value === 0 || document.isAuxiliary()) {
+      return this.right();
+    }
+
+    return await this.uploadDocument(document, path);
+  }
+
+  private async uploadDocument(document: any, path: string) {
+    try {
+      await this.container.get(TemporalFileUploader).run(document.path.value);
+      this.logDebugMessage('File has been uploaded');
+      return this.right();
+    } catch (uploadError) {
+      Logger.error('Upload failed:', uploadError);
+      await this.container.get(TemporalFileDeleter).run(path);
+      return this.left(
+        new FuseIOError(
+          'Upload failed due to insufficient storage or network issues.'
+        )
+      );
+    }
+  }
+
+  private async findVirtualFile(path: string) {
+    return this.container.get(FirstsFileSearcher).run({ path });
+  }
+
+  private async handleVirtualFile(virtualFile: any) {
+    await this.container.get(StorageCacheDeleter).run(virtualFile.contentsId);
+    this.logDebugMessage(`${virtualFile.path} removed from local file cache`);
+    return this.right();
   }
 }

--- a/src/context/storage/TemporalFiles/application/creation/TemporalFileCreator.ts
+++ b/src/context/storage/TemporalFiles/application/creation/TemporalFileCreator.ts
@@ -9,6 +9,6 @@ export class TemporalFileCreator {
   async run(path: string): Promise<void> {
     const documentPath = new TemporalFilePath(path);
 
-    this.repository.create(documentPath);
+    await this.repository.create(documentPath);
   }
 }

--- a/src/context/storage/TemporalFiles/infrastructure/NodeTemporalFileRepository.ts
+++ b/src/context/storage/TemporalFiles/infrastructure/NodeTemporalFileRepository.ts
@@ -42,6 +42,7 @@ export class NodeTemporalFileRepository implements TemporalFileRepository {
   }
 
   create(documentPath: TemporalFilePath): Promise<void> {
+    Logger.debug('Creating file', documentPath.value);
     const id = uuid.v4();
 
     const pathToWrite = path.join(this.folder, id);
@@ -165,6 +166,7 @@ export class NodeTemporalFileRepository implements TemporalFileRepository {
   }
 
   async find(documentPath: TemporalFilePath): Promise<Optional<TemporalFile>> {
+    Logger.debug('Finding file', documentPath.value);
     const pathToSearch = this.map.get(documentPath.value);
 
     if (!pathToSearch) {
@@ -185,6 +187,8 @@ export class NodeTemporalFileRepository implements TemporalFileRepository {
 
   watchFile(documentPath: TemporalFilePath, callback: () => void): () => void {
     const pathToWatch = this.map.get(documentPath.value);
+
+    Logger.debug('Watching file', documentPath.value);
 
     if (!pathToWatch) {
       throw new Error(`Document with path ${documentPath.value} not found`);


### PR DESCRIPTION
the logs showed IO error even when the user had no free space left, if any file surpased the available storage the entire sync would fail. Now any smaller files that are able to be uploaded are uploaded, and the failing file or files are deleted from Fuse, previously the failing files would remain on the Internxt Drive folder causing confusion as to wheter it was succesfullt uploaded.

This also introduces fixes to sync stability, although I didn't find a bug reported that fitted this case.