### PR TITLE
[PB-2404, PB-3721,PB-3751]: feat/increase upload limit

### DIFF
--- a/src/apps/backups/dependency-injection/local/registerLocalFileServices.ts
+++ b/src/apps/backups/dependency-injection/local/registerLocalFileServices.ts
@@ -9,7 +9,6 @@ import { DependencyInjectionMnemonicProvider } from '../../../shared/dependency-
 import { AuthorizedClients } from '../../../shared/HttpClient/Clients';
 import { LocalFileMessenger } from '../../../../context/local/localFile/domain/LocalFileMessenger';
 import { RendererIpcLocalFileMessenger } from '../../../../context/local/localFile/infrastructure/RendererIpcLocalFileMessenger';
-import Logger from 'electron-log';
 
 export function registerLocalFileServices(builder: ContainerBuilder) {
   //Infra
@@ -23,23 +22,12 @@ export function registerLocalFileServices(builder: ContainerBuilder) {
     encryptionKey: mnemonic,
   });
 
-  // Log the environment configuration
-  Logger.info('Environment configuration:', {
-    bridgeUrl: environment.config.bridgeUrl,
-    bridgeUser: environment.config.bridgeUser,
-    bridgePass: environment.config.bridgePass,
-    encryptionKey: environment.config.encryptionKey,
-  });
-
   builder.register(Environment).useInstance(environment).private();
 
   builder
     .register(LocalFileHandler)
     .useFactory((c) => {
       const env = c.get(Environment);
-      // Log the environment retrieved from the container
-      Logger.debug('Environment:', env);
-
       return new EnvironmentLocalFileUploader(
         env,
         user.backupsBucket,

--- a/src/context/local/localFile/application/upload/FileBatchUploader.ts
+++ b/src/context/local/localFile/application/upload/FileBatchUploader.ts
@@ -23,12 +23,18 @@ export class FileBatchUploader {
     signal: AbortSignal
   ): Promise<void> {
     for (const localFile of batch) {
-      // eslint-disable-next-line no-await-in-loop
-      const uploadEither = await this.localHandler.upload(
-        localFile.path,
-        localFile.size,
-        signal
-      );
+      let uploadEither;
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        uploadEither = await this.localHandler.upload(
+          localFile.path,
+          localFile.size,
+          signal
+        );
+      } catch (error) {
+        Logger.error('[UPLOAD ERROR]', error);
+        continue;
+      }
 
       if (uploadEither.isLeft()) {
         const error = uploadEither.getLeft();

--- a/src/context/local/localFile/infrastructure/EnvironmentLocalFileUploader.ts
+++ b/src/context/local/localFile/infrastructure/EnvironmentLocalFileUploader.ts
@@ -37,40 +37,26 @@ export class EnvironmentLocalFileUploader implements LocalFileHandler {
     stopwatch.start();
 
     return new Promise<Either<DriveDesktopError, string>>((resolve) => {
-      Logger.info('[ENVLFU UPLOAD]', fn);
-      Logger.info('[ENVLFU Environment]', this.environment);
-      Logger.info(
-        '[ENVLFU Environment uploadMultipartFile]',
-        this.environment.uploadMultipartFile
-      );
-      Logger.info(
-        '[ENVLFU Environment isMultipartUpload]',
-        fn === this.environment.uploadMultipartFile
-      );
-      const state = fn(
-        this.bucket,
-        {
-          source: readable,
-          fileSize: size,
-          finishedCallback: (err: Error | null, contentsId: string) => {
-            stopwatch.finish();
+      const state = fn(this.bucket, {
+        source: readable,
+        fileSize: size,
+        finishedCallback: (err: Error | null, contentsId: string) => {
+          stopwatch.finish();
 
-            if (err) {
-              Logger.error('[ENVLFU UPLOAD ERROR]', err);
-              if (err.message === 'Max space used') {
-                return resolve(left(new DriveDesktopError('NOT_ENOUGH_SPACE')));
-              }
-              return resolve(left(new DriveDesktopError('UNKNOWN')));
+          if (err) {
+            Logger.error('[ENVLFU UPLOAD ERROR]', err);
+            if (err.message === 'Max space used') {
+              return resolve(left(new DriveDesktopError('NOT_ENOUGH_SPACE')));
             }
+            return resolve(left(new DriveDesktopError('UNKNOWN')));
+          }
 
-            resolve(right(contentsId));
-          },
-          progressCallback: (progress: number) => {
-            Logger.debug('[UPLOAD PROGRESS]', progress);
-          },
+          resolve(right(contentsId));
         },
-        Logger
-      );
+        progressCallback: (progress: number) => {
+          Logger.debug('[UPLOAD PROGRESS]', progress);
+        },
+      });
 
       abortSignal.addEventListener('abort', () => {
         state.stop();

--- a/src/context/shared/domain/value-objects/BucketEntry.ts
+++ b/src/context/shared/domain/value-objects/BucketEntry.ts
@@ -1,7 +1,7 @@
 import { ValueObject } from './ValueObject';
 
 export class BucketEntry extends ValueObject<number> {
-  public static MAX_SIZE = 20 * 1024 * 1024 * 1024;
+  public static MAX_SIZE = 40 * 1024 * 1024 * 1024;
 
   constructor(value: number) {
     super(value);

--- a/src/context/storage/TemporalFiles/infrastructure/upload/EnvironmentTemporalFileUploaderFactory.ts
+++ b/src/context/storage/TemporalFiles/infrastructure/upload/EnvironmentTemporalFileUploaderFactory.ts
@@ -102,8 +102,8 @@ export class EnvironmentTemporalFileUploaderFactory
     const fn =
       document.size.value >
       EnvironmentTemporalFileUploaderFactory.MULTIPART_UPLOAD_SIZE_THRESHOLD
-        ? this.environment.uploadMultipartFile
-        : this.environment.upload;
+        ? this.environment.uploadMultipartFile.bind(this.environment)
+        : this.environment.upload.bind(this.environment);
 
     const uploader = new EnvironmentTemporalFileUploader(
       fn,


### PR DESCRIPTION
Increase upload limits to 40gb. While doing so during testing I found that uploadMultiPart function was failing in both backups and sync, meaning that uploading any file > 5gb would fail, and in the case of bakcups cause the entire backup to fail when one such file was encountered. 