### PR TITLE
feat/v2.4.2

### DIFF
--- a/assets/python-nautilus/internxt-virtual-drive.py
+++ b/assets/python-nautilus/internxt-virtual-drive.py
@@ -11,7 +11,7 @@ SYNC_STATUS_ATTRIBUTE ="SYNC_STATUS"
 SYNC_STATUS_ATTRIBUTE_NAME ="Sync Status"
 SYNC_STATUS_ONLY_ONLINE="Only online"
 
-VIRTUAL_DRIVE_ROOT_FOLDER_NAME = "Internxt%20Drive"
+VIRTUAL_DRIVE_ROOT_FOLDER_NAME = "Internxt"
 
 status_to_column_status_map = {
   "on_local": "Offline Available",

--- a/assets/python-nautilus/internxt-virtual-drive.py
+++ b/assets/python-nautilus/internxt-virtual-drive.py
@@ -11,7 +11,7 @@ SYNC_STATUS_ATTRIBUTE ="SYNC_STATUS"
 SYNC_STATUS_ATTRIBUTE_NAME ="Sync Status"
 SYNC_STATUS_ONLY_ONLINE="Only online"
 
-VIRTUAL_DRIVE_ROOT_FOLDER_NAME = "Internxt"
+VIRTUAL_DRIVE_ROOT_FOLDER_NAME = "Internxt%20Drive"
 
 status_to_column_status_map = {
   "on_local": "Offline Available",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internxt-drive",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "author": "Internxt <hello@internxt.com>",
   "description": "Internxt Drive client UI",
   "license": "AGPL-3.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "internxt-drive",
+  "name": "internxt",
   "version": "2.4.2",
   "author": "Internxt <hello@internxt.com>",
   "description": "Internxt Drive client UI",
@@ -45,7 +45,7 @@
     ]
   },
   "build": {
-    "productName": "Internxt Drive",
+    "productName": "Internxt",
     "beforeBuild": "./beforeBuild.js",
     "appId": "com.internxt.drive",
     "asar": true,

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internxt-drive",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Internxt Drive client UI",
   "main": "./dist/main/main.js",
   "author": "Internxt <hello@internxt.com>",

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "internxt-drive",
+  "name": "internxt",
   "version": "2.4.2",
   "description": "Internxt Drive client UI",
   "main": "./dist/main/main.js",

--- a/src/apps/backups/BackupError.ts
+++ b/src/apps/backups/BackupError.ts
@@ -1,15 +1,34 @@
-type BackupErrorCause =
-  | 'NOT_EXISTS'
-  | 'NO_PERMISSION'
-  | 'NO_INTERNET'
-  | 'NO_REMOTE_CONNECTION'
-  | 'BAD_RESPONSE'
-  | 'EMPTY_FILE'
-  | 'FILE_TOO_BIG'
-  | 'FILE_NON_EXTENSION'
-  | 'UNKNOWN'
-  | 'FILE_ALREADY_EXISTS'
-  | 'FOLDER_ALREADY_EXISTS';
+const BackupErrorCauses = [
+  'NOT_EXISTS',
+  'NO_PERMISSION',
+  'NO_INTERNET',
+  'NO_REMOTE_CONNECTION',
+  'BAD_RESPONSE',
+  'EMPTY_FILE',
+  'FILE_TOO_BIG',
+  'FILE_NON_EXTENSION',
+  'SERVER_ERROR',
+  'UNKNOWN',
+  'FILE_ALREADY_EXISTS',
+  'FOLDER_ALREADY_EXISTS',
+] as const;
+
+export type BackupErrorCause = (typeof BackupErrorCauses)[number];
+
+export const BackUpErrorCauseEnum: { [K in BackupErrorCause]: K } = {
+  NOT_EXISTS: 'NOT_EXISTS',
+  NO_PERMISSION: 'NO_PERMISSION',
+  NO_INTERNET: 'NO_INTERNET',
+  NO_REMOTE_CONNECTION: 'NO_REMOTE_CONNECTION',
+  BAD_RESPONSE: 'BAD_RESPONSE',
+  EMPTY_FILE: 'EMPTY_FILE',
+  FILE_TOO_BIG: 'FILE_TOO_BIG',
+  FILE_NON_EXTENSION: 'FILE_NON_EXTENSION',
+  SERVER_ERROR: 'SERVER_ERROR',
+  UNKNOWN: 'UNKNOWN',
+  FILE_ALREADY_EXISTS: 'FILE_ALREADY_EXISTS',
+  FOLDER_ALREADY_EXISTS: 'FOLDER_ALREADY_EXISTS',
+} as const;
 
 export class BackupError extends Error {
   constructor(public readonly cause: BackupErrorCause) {

--- a/src/apps/backups/batches/GroupFilesInChunksBySize.ts
+++ b/src/apps/backups/batches/GroupFilesInChunksBySize.ts
@@ -32,7 +32,7 @@ export class GroupFilesInChunksBySize {
   }
 
   static empty(all: Array<LocalFile>): Chucks {
-    return GroupFilesInChunksBySize.chunk(all, 1);
+    return GroupFilesInChunksBySize.chunk(all, all.length);
   }
 
   private static chunk(files: Array<LocalFile>, size: number) {

--- a/src/apps/backups/dependency-injection/local/registerLocalFileServices.ts
+++ b/src/apps/backups/dependency-injection/local/registerLocalFileServices.ts
@@ -13,7 +13,6 @@ import { RendererIpcLocalFileMessenger } from '../../../../context/local/localFi
 export function registerLocalFileServices(builder: ContainerBuilder) {
   //Infra
   const user = DependencyInjectionUserProvider.get();
-
   const mnemonic = DependencyInjectionMnemonicProvider.get();
 
   const environment = new Environment({
@@ -27,15 +26,15 @@ export function registerLocalFileServices(builder: ContainerBuilder) {
 
   builder
     .register(LocalFileHandler)
-    .useFactory(
-      (c) =>
-        new EnvironmentLocalFileUploader(
-          c.get(Environment),
-          user.backupsBucket,
-          //@ts-ignore
-          c.get(AuthorizedClients).drive
-        )
-    )
+    .useFactory((c) => {
+      const env = c.get(Environment);
+      return new EnvironmentLocalFileUploader(
+        env,
+        user.backupsBucket,
+        //@ts-ignore
+        c.get(AuthorizedClients).drive
+      );
+    })
     .private();
 
   builder

--- a/src/apps/backups/index.ts
+++ b/src/apps/backups/index.ts
@@ -22,7 +22,7 @@ async function obtainBackup(): Promise<BackupInfo> {
   }
 }
 
-async function backupFolder() {
+export async function backupFolder() {
   const data = await obtainBackup();
 
   try {

--- a/src/apps/main/background-processes/backups/BackupsIpc.ts
+++ b/src/apps/main/background-processes/backups/BackupsIpc.ts
@@ -1,7 +1,7 @@
 import { ipcMain } from 'electron';
 import { TypedIPC } from '../../../shared/IPC/TypedIPC';
-import { BackgroundProcessBackupsMessages } from '../../../shared/IPC/events/backups/BackgroundProcessBackupsMessages';
 import { MainProcessBackupsMessages } from '../../../shared/IPC/events/backups/MainProcessBackupsMessages';
+import { BackgroundProcessBackupsMessages } from '../../../shared/IPC/events/backups/BackgroundProcessBackupsMessages';
 
 type BackupsIPCMain = TypedIPC<
   BackgroundProcessBackupsMessages,

--- a/src/apps/main/migration/service.ts
+++ b/src/apps/main/migration/service.ts
@@ -4,7 +4,7 @@ import { app, shell } from 'electron';
 import fsExtra from 'fs-extra';
 import configStore from '../config';
 import Logger from 'electron-log';
-const DESKTOP_FOLDER_NAME = 'Moved files (Internxt)';
+const DESKTOP_FOLDER_NAME = 'Moved files (Internxt Drive)';
 
 export const openMigrationFailedFolder = async () => {
   const desktopFolderPath = path.join(

--- a/src/apps/main/migration/service.ts
+++ b/src/apps/main/migration/service.ts
@@ -4,7 +4,7 @@ import { app, shell } from 'electron';
 import fsExtra from 'fs-extra';
 import configStore from '../config';
 import Logger from 'electron-log';
-const DESKTOP_FOLDER_NAME = 'Moved files (Internxt Drive)';
+const DESKTOP_FOLDER_NAME = 'Moved files (Internxt)';
 
 export const openMigrationFailedFolder = async () => {
   const desktopFolderPath = path.join(

--- a/src/apps/main/preload.d.ts
+++ b/src/apps/main/preload.d.ts
@@ -146,9 +146,7 @@ declare interface Window {
     };
 
     onDeviceCreated(
-      func: (
-        value: import('../main/device/service').Device
-      ) => void
+      func: (value: import('../main/device/service').Device) => void
     ): () => void;
 
     getBackupsFromDevice: typeof import('../main/device/service').getBackupsFromDevice;
@@ -189,9 +187,9 @@ declare interface Window {
 
     getFolderPath: typeof import('../main/device/service').getPathFromDialog;
 
-    onRemoteChanges(func: (
-      value: import('../main/realtime').EventPayload
-    ) => void): () => void;
+    onRemoteChanges(
+      func: (value: import('../main/realtime').EventPayload) => void
+    ): () => void;
 
     getUsage: () => Promise<import('./usage/Usage').Usage>;
 
@@ -229,5 +227,8 @@ declare interface Window {
       hasDiscoveredBackups: () => Promise<boolean>;
       discoveredBackups: () => Promise<void>;
     };
+    onBackupFailed: (
+      callback: (error: { message: string; cause: string }) => void
+    ) => () => void;
   };
 }

--- a/src/apps/main/preload.js
+++ b/src/apps/main/preload.js
@@ -336,4 +336,8 @@ contextBridge.exposeInMainWorld('electron', {
       ipcRenderer.send('user.set-has-discovered-backups');
     },
   },
+  onBackupFailed(callback) {
+    ipcRenderer.on('backup-failed', (_, error) => callback(error));
+    return () => ipcRenderer.removeListener('backup-failed', callback);
+  },
 });

--- a/src/apps/main/tray/tray.ts
+++ b/src/apps/main/tray/tray.ts
@@ -95,9 +95,9 @@ export class TrayMenu {
   setTooltip(state: TrayMenuState) {
     const messages: Record<TrayMenuState, string> = {
       SYNCING: 'Sync in process',
-      IDLE: `Internxt Drive ${PackageJson.version}`,
+      IDLE: `Internxt ${PackageJson.version}`,
       ALERT: 'There are some issues with your sync',
-      LOADING: 'Loading Internxt Drive...',
+      LOADING: 'Loading Internxt...',
     };
 
     const message = messages[state];

--- a/src/apps/main/virtual-root-folder/service.ts
+++ b/src/apps/main/virtual-root-folder/service.ts
@@ -6,7 +6,7 @@ import eventBus from '../event-bus';
 import { exec } from 'child_process';
 import { ensureFolderExists } from '../../shared/fs/ensure-folder-exists';
 
-const ROOT_FOLDER_NAME = 'Internxt Drive';
+const ROOT_FOLDER_NAME = 'Internxt';
 const HOME_FOLDER_PATH = app.getPath('home');
 
 const VIRTUAL_DRIVE_FOLDER = path.join(HOME_FOLDER_PATH, ROOT_FOLDER_NAME);

--- a/src/apps/main/virtual-root-folder/service.ts
+++ b/src/apps/main/virtual-root-folder/service.ts
@@ -6,7 +6,7 @@ import eventBus from '../event-bus';
 import { exec } from 'child_process';
 import { ensureFolderExists } from '../../shared/fs/ensure-folder-exists';
 
-const ROOT_FOLDER_NAME = 'Internxt';
+const ROOT_FOLDER_NAME = 'Internxt Drive';
 const HOME_FOLDER_PATH = app.getPath('home');
 
 const VIRTUAL_DRIVE_FOLDER = path.join(HOME_FOLDER_PATH, ROOT_FOLDER_NAME);

--- a/src/apps/renderer/App.tsx
+++ b/src/apps/renderer/App.tsx
@@ -17,7 +17,7 @@ import Settings from './pages/Settings';
 import Widget from './pages/Widget';
 import Migration from './pages/Migration';
 import Feedback from './pages/Feedback';
-
+import { useBackupNotifications } from './hooks/useBackupNotifications';
 function LocationWrapper({ children }: { children: JSX.Element }) {
   const { pathname } = useLocation();
   useEffect(() => {
@@ -55,6 +55,7 @@ function Loader() {
 
 export default function App() {
   useLanguageChangedListener();
+  useBackupNotifications();
 
   return (
     <Router>

--- a/src/apps/renderer/context/DeviceContext.tsx
+++ b/src/apps/renderer/context/DeviceContext.tsx
@@ -35,7 +35,8 @@ export function DeviceProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     refreshDevice();
 
-    const removeDeviceCreatedListener = window.electron.onDeviceCreated(setCurrentDevice);
+    const removeDeviceCreatedListener =
+      window.electron.onDeviceCreated(setCurrentDevice);
     return () => {
       removeDeviceCreatedListener();
     };
@@ -43,13 +44,15 @@ export function DeviceProvider({ children }: { children: ReactNode }) {
 
   const refreshDevice = () => {
     setDeviceState({ status: 'LOADING' });
-    window.electron.getOrCreateDevice().then((device) => {
-      setCurrentDevice(device);
-    })
-    .catch(() => {
-      setDeviceState({ status: 'ERROR' });
-    });;
-  }
+    window.electron
+      .getOrCreateDevice()
+      .then((device) => {
+        setCurrentDevice(device);
+      })
+      .catch(() => {
+        setDeviceState({ status: 'ERROR' });
+      });
+  };
 
   const setCurrentDevice = (newDevice: Device) => {
     try {
@@ -59,7 +62,7 @@ export function DeviceProvider({ children }: { children: ReactNode }) {
     } catch {
       setDeviceState({ status: 'ERROR' });
     }
-  }
+  };
 
   const deviceRename = async (deviceName: string) => {
     setDeviceState({ status: 'LOADING' });

--- a/src/apps/renderer/hooks/useBackupNotifications.tsx
+++ b/src/apps/renderer/hooks/useBackupNotifications.tsx
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+import { useTranslationContext } from '../context/LocalContext';
+
+export function useBackupNotifications() {
+  const { translate } = useTranslationContext();
+
+  useEffect(() => {
+    const handleBackupFailed = (error: { message: string; cause: string }) => {
+      let notificationTitle = '';
+      let notificationBody = '';
+
+      switch (error.cause) {
+        case 'NO_INTERNET':
+          notificationTitle = translate('backupErrors.noInternet.title');
+          notificationBody = translate('backupErrors.noInternet.message');
+          break;
+        case 'SERVER_ERROR':
+          notificationTitle = translate('backupErrors.serverError.title');
+          notificationBody = translate('backupErrors.serverError.message');
+          break;
+        case 'CLIENT_ERROR':
+          notificationTitle = translate('backupErrors.clientError.title');
+          notificationBody = translate('backupErrors.clientError.message');
+          break;
+        default:
+          notificationTitle = translate('backupErrors.generic.title');
+          notificationBody = translate('backupErrors.generic.message');
+          break;
+      }
+
+      new Notification(notificationTitle, {
+        body: notificationBody,
+      });
+    };
+
+    const removeListener = window.electron.onBackupFailed(handleBackupFailed);
+
+    return () => {
+      removeListener();
+    };
+  }, [translate]);
+}

--- a/src/apps/renderer/index.ejs
+++ b/src/apps/renderer/index.ejs
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Internxt Drive</title>
+    <title>Internxt</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/apps/renderer/localize/locales/en.json
+++ b/src/apps/renderer/localize/locales/en.json
@@ -217,7 +217,7 @@
           "save": "Save"
         }
       },
-      "auto-startup": "Start Internxt Drive on system startup",
+      "auto-startup": "Start Internxt on system startup",
       "language": {
         "label": "Language",
         "options": {
@@ -241,7 +241,7 @@
       "app-info": {
         "open-logs": "Open logs",
         "open-migration": "Start migration",
-        "more": "Learn more about Internxt Drive"
+        "more": "Learn more about Internxt"
       }
     },
     "account": {

--- a/src/apps/renderer/localize/locales/en.json
+++ b/src/apps/renderer/localize/locales/en.json
@@ -386,5 +386,27 @@
   },
   "common": {
     "cancel": "Cancel"
+  },
+  "backupErrors": {
+    "noInternet": {
+      "title": "Backup Failed",
+      "message": "Network connection lost. Please check your internet and try again."
+    },
+    "serverError": {
+      "title": "Backup Failed",
+      "message": "Server error occurred while performing the backup. Please try again later."
+    },
+    "clientError": {
+      "title": "Backup Failed",
+      "message": "An error occurred on your device during the backup process."
+    },
+    "generic": {
+      "title": "Backup Failed",
+      "message": "An unexpected error occurred during the backup process."
+    }
+  },
+  "networkConnectionLost": {
+    "title": "Network connection lost",
+    "message": "Your network connection has been lost. Please check your internet connection and try again."
   }
 }

--- a/src/apps/renderer/localize/locales/es.json
+++ b/src/apps/renderer/localize/locales/es.json
@@ -385,5 +385,27 @@
   },
   "common": {
     "cancel": "Cancelar"
+  },
+  "backupErrors": {
+    "noInternet": {
+      "title": "Error en la Copia de Seguridad",
+      "message": "Conexión de red perdida. Por favor, verifica tu internet e inténtalo de nuevo."
+    },
+    "serverError": {
+      "title": "Error en la Copia de Seguridad",
+      "message": "Se produjo un error en el servidor durante la copia de seguridad. Por favor, inténtalo de nuevo más tarde."
+    },
+    "clientError": {
+      "title": "Error en la Copia de Seguridad",
+      "message": "Se produjo un error en tu dispositivo durante el proceso de copia de seguridad."
+    },
+    "generic": {
+      "title": "Error en la Copia de Seguridad",
+      "message": "Ocurrió un error inesperado durante el proceso de copia de seguridad."
+    }
+  },
+  "networkConnectionLost": {
+    "title": "Conexión de red perdida",
+    "message": "Se ha perdido la conexión de red. Por favor, verifica tu conexión a internet e inténtalo de nuevo."
   }
 }

--- a/src/apps/renderer/localize/locales/es.json
+++ b/src/apps/renderer/localize/locales/es.json
@@ -217,7 +217,7 @@
           "save": "Guardar"
         }
       },
-      "auto-startup": "Iniciar Internxt Drive al arrancar el sistema",
+      "auto-startup": "Iniciar Internxt al arrancar el sistema",
       "language": {
         "label": "Idioma",
         "options": {
@@ -241,7 +241,7 @@
       "app-info": {
         "open-logs": "Abrir registros",
         "open-migration": "Empezar migración",
-        "more": "Más información sobre Internxt Drive"
+        "more": "Más información sobre Internxt"
       }
     },
     "account": {

--- a/src/apps/renderer/localize/locales/fr.json
+++ b/src/apps/renderer/localize/locales/fr.json
@@ -213,7 +213,7 @@
           "save": "Enregistrer"
         }
       },
-      "auto-startup": "Démarrer Internxt Drive au démarrage du système",
+      "auto-startup": "Démarrer Internxt au démarrage du système",
       "language": {
         "label": "Langue",
         "options": {
@@ -236,7 +236,7 @@
       },
       "app-info": {
         "open-logs": "Ouvrir les registres",
-        "more": "Plus d'informations sur Internxt Drive"
+        "more": "Plus d'informations sur Internxt"
       }
     },
     "account": {

--- a/src/apps/renderer/localize/locales/fr.json
+++ b/src/apps/renderer/localize/locales/fr.json
@@ -379,5 +379,27 @@
   },
   "common": {
     "cancel": "Annuler"
+  },
+  "backupErrors": {
+    "noInternet": {
+      "title": "Erreur de Copie de Sécurité",
+      "message": "La connexion internet a été perdue. Veuillez vérifier votre connexion Internet et réessayer."
+    },
+    "serverError": {
+      "title": "Erreur de Copie de Sécurité",
+      "message": "Une erreur est survenue sur le serveur lors de la copie de sécurité. Veuillez réessayer plus tard."
+    },
+    "clientError": {
+      "title": "Erreur de Copie de Sécurité",
+      "message": "Une erreur est survenue sur votre appareil lors de la copie de sécurité."
+    },
+    "generic": {
+      "title": "Erreur de Copie de Sécurité",
+      "message": "Une erreur inattendue est survenue lors de la copie de sécurité."
+    }
+  },
+  "networkConnectionLost": {
+    "title": "Connexion réseau perdue",
+    "message": "Votre connexion réseau a été perdue. Veuillez vérifier votre connexion Internet et réessayer."
   }
 }

--- a/src/apps/renderer/pages/Login/index.tsx
+++ b/src/apps/renderer/pages/Login/index.tsx
@@ -226,13 +226,10 @@ export default function Login() {
 
   return (
     <div className="relative flex h-screen flex-col overflow-hidden bg-surface dark:bg-gray-1">
-      <WindowTopBar
-        title="Internxt Drive"
-        className="bg-surface dark:bg-gray-5"
-      />
+      <WindowTopBar title="Internxt" className="bg-surface dark:bg-gray-5" />
 
       <div className="flex h-32 flex-col items-center justify-center">
-        <h1 className="text-xl font-semibold text-gray-100">Internxt Drive</h1>
+        <h1 className="text-xl font-semibold text-gray-100">Internxt</h1>
         <h2 className="text-supporting-1 font-semibold text-gray-60">
           v{packageJson.version}
         </h2>

--- a/src/apps/renderer/pages/Settings/General/AppInfo.tsx
+++ b/src/apps/renderer/pages/Settings/General/AppInfo.tsx
@@ -16,7 +16,7 @@ export default function AppInfo() {
     <div className="mt-auto flex flex-col space-y-4">
       <div className="relative flex h-2 before:absolute before:inset-x-0 before:top-1/2 before:h-px before:-translate-y-1/2 before:bg-gray-10" />
       <p className="text-sm leading-4 text-gray-100">
-        Internxt Drive v{packageJson.version}
+        Internxt v{packageJson.version}
       </p>
 
       <div className="flex flex-col items-start space-y-1 text-base leading-5">

--- a/src/apps/renderer/pages/Settings/index.tsx
+++ b/src/apps/renderer/pages/Settings/index.tsx
@@ -47,7 +47,7 @@ export default function Settings() {
           {subsection === 'panel' && (
             <div className="flex flex-grow flex-col">
               <WindowTopBar
-                title="Internxt Drive"
+                title="Internxt"
                 className="bg-surface dark:bg-gray-5"
               />
               <Header active={activeSection} onClick={setActiveSection} />

--- a/src/apps/renderer/pages/Widget/SyncAction.tsx
+++ b/src/apps/renderer/pages/Widget/SyncAction.tsx
@@ -7,6 +7,7 @@ import { useTranslationContext } from '../../context/LocalContext';
 import useVirtualDriveStatus from '../../hooks/useVirtualDriveStatus';
 import useSyncStatus from '../../hooks/useSyncStatus';
 import useUsage from '../../hooks/useUsage';
+import isOnline from '../../../utils/is-online';
 
 export default function SyncAction(props: { syncStatus: SyncStatus }) {
   const { translate } = useTranslationContext();
@@ -30,16 +31,20 @@ export default function SyncAction(props: { syncStatus: SyncStatus }) {
   };
 
   useEffect(() => {
-    const updateOnlineStatus = () => {
-      setIsOnLine(navigator.onLine);
+    const updateOnlineStatus = async () => {
+      const online = await isOnline();
+      setIsOnLine(online);
     };
 
     updateOnlineStatus();
+
+    const intervalId = setInterval(updateOnlineStatus, 60000 * 5);
 
     window.addEventListener('online', updateOnlineStatus);
     window.addEventListener('offline', updateOnlineStatus);
 
     return () => {
+      clearInterval(intervalId);
       window.removeEventListener('online', updateOnlineStatus);
       window.removeEventListener('offline', updateOnlineStatus);
     };

--- a/src/apps/renderer/pages/Widget/SyncAction.tsx
+++ b/src/apps/renderer/pages/Widget/SyncAction.tsx
@@ -30,8 +30,28 @@ export default function SyncAction(props: { syncStatus: SyncStatus }) {
   };
 
   useEffect(() => {
-    setIsOnLine(navigator.onLine);
-  });
+    const updateOnlineStatus = () => {
+      setIsOnLine(navigator.onLine);
+    };
+
+    updateOnlineStatus();
+
+    window.addEventListener('online', updateOnlineStatus);
+    window.addEventListener('offline', updateOnlineStatus);
+
+    return () => {
+      window.removeEventListener('online', updateOnlineStatus);
+      window.removeEventListener('offline', updateOnlineStatus);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isOnLine) {
+      new Notification(translate('networkConnectionLost.title'), {
+        body: translate('networkConnectionLost.message'),
+      });
+    }
+  }, [isOnLine, translate]);
 
   return (
     <div className="flex h-11 shrink-0 items-center space-x-2.5 border-t border-gray-10 px-2.5 text-sm font-medium text-gray-100 dark:border-gray-5">

--- a/src/context/local/localFile/application/upload/FileBatchUploader.ts
+++ b/src/context/local/localFile/application/upload/FileBatchUploader.ts
@@ -23,12 +23,18 @@ export class FileBatchUploader {
     signal: AbortSignal
   ): Promise<void> {
     for (const localFile of batch) {
-      // eslint-disable-next-line no-await-in-loop
-      const uploadEither = await this.localHandler.upload(
-        localFile.path,
-        localFile.size,
-        signal
-      );
+      let uploadEither;
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        uploadEither = await this.localHandler.upload(
+          localFile.path,
+          localFile.size,
+          signal
+        );
+      } catch (error) {
+        Logger.error('[UPLOAD ERROR]', error);
+        continue;
+      }
 
       if (uploadEither.isLeft()) {
         const error = uploadEither.getLeft();

--- a/src/context/local/localFile/infrastructure/EnvironmentLocalFileUploader.ts
+++ b/src/context/local/localFile/infrastructure/EnvironmentLocalFileUploader.ts
@@ -27,8 +27,8 @@ export class EnvironmentLocalFileUploader implements LocalFileHandler {
   ): Promise<Either<DriveDesktopError, string>> {
     const fn: UploadStrategyFunction =
       size > EnvironmentLocalFileUploader.MULTIPART_UPLOAD_SIZE_THRESHOLD
-        ? this.environment.uploadMultipartFile
-        : this.environment.upload;
+        ? this.environment.uploadMultipartFile.bind(this.environment)
+        : this.environment.upload.bind(this.environment);
 
     const readable = createReadStream(path);
 

--- a/src/context/shared/domain/value-objects/BucketEntry.ts
+++ b/src/context/shared/domain/value-objects/BucketEntry.ts
@@ -1,7 +1,7 @@
 import { ValueObject } from './ValueObject';
 
 export class BucketEntry extends ValueObject<number> {
-  public static MAX_SIZE = 20 * 1024 * 1024 * 1024;
+  public static MAX_SIZE = 40 * 1024 * 1024 * 1024;
 
   constructor(value: number) {
     super(value);

--- a/src/context/storage/TemporalFiles/infrastructure/upload/EnvironmentTemporalFileUploaderFactory.ts
+++ b/src/context/storage/TemporalFiles/infrastructure/upload/EnvironmentTemporalFileUploaderFactory.ts
@@ -102,8 +102,8 @@ export class EnvironmentTemporalFileUploaderFactory
     const fn =
       document.size.value >
       EnvironmentTemporalFileUploaderFactory.MULTIPART_UPLOAD_SIZE_THRESHOLD
-        ? this.environment.uploadMultipartFile
-        : this.environment.upload;
+        ? this.environment.uploadMultipartFile.bind(this.environment)
+        : this.environment.upload.bind(this.environment);
 
     const uploader = new EnvironmentTemporalFileUploader(
       fn,

--- a/src/context/storage/thumbnails/infrastructrue/local/LocalThumbnsailsRepository.ts
+++ b/src/context/storage/thumbnails/infrastructrue/local/LocalThumbnsailsRepository.ts
@@ -165,7 +165,7 @@ export class LocalThumbnailRepository implements ThumbnailsRepository {
 
     try {
       const thumbnail = fs.readFileSync(iconPath);
-      where.forEach((p) => fs.writeFileSync(p, thumbnail));
+      where.forEach((p) => fs.writeFileSync(p, new Uint8Array(thumbnail)));
       Logger.debug(file.nameWithExtension, 'thumbnail created');
     } catch (err) {
       Logger.error(file.nameWithExtension, err);

--- a/src/context/virtual-drive/folders/domain/FolderPath.ts
+++ b/src/context/virtual-drive/folders/domain/FolderPath.ts
@@ -14,7 +14,7 @@ export class FolderPath extends Path {
 
   name(): string {
     if (this.value === path.posix.sep) {
-      return 'Internxt Drive';
+      return 'Internxt';
     }
 
     return super.basename();

--- a/tests/apps/backups/Backup.test.ts
+++ b/tests/apps/backups/Backup.test.ts
@@ -1,0 +1,211 @@
+import { Backup } from '../../../src/apps/backups/Backup';
+import LocalTreeBuilder from '../../../src/context/local/localTree/application/LocalTreeBuilder';
+import { RemoteTreeBuilder } from '../../../src/context/virtual-drive/remoteTree/application/RemoteTreeBuilder';
+import { FileBatchUploader } from '../../../src/context/local/localFile/application/upload/FileBatchUploader';
+import { FileBatchUpdater } from '../../../src/context/local/localFile/application/update/FileBatchUpdater';
+import { FileDeleter } from '../../../src/context/virtual-drive/files/application/delete/FileDeleter';
+import { SimpleFolderCreator } from '../../../src/context/virtual-drive/folders/application/create/SimpleFolderCreator';
+import { UserAvaliableSpaceValidator } from '../../../src/context/user/usage/application/UserAvaliableSpaceValidator';
+import { BackupInfo } from '../../../src/apps/backups/BackupInfo';
+import { DriveDesktopError } from '../../../src/context/shared/domain/errors/DriveDesktopError';
+import { LocalTreeMother } from '../../context/local/tree/domain/LocalTreeMother';
+import { RemoteTreeMother } from '../../context/virtual-drive/tree/domain/RemoteTreeMother';
+import { left, right } from '../../../src/context/shared/domain/Either';
+import { RemoteTree } from '../../../src/context/virtual-drive/remoteTree/domain/RemoteTree';
+import { jest } from '@jest/globals';
+import { BackupsIPCRenderer } from '../../../src/apps/backups/BackupsIPCRenderer';
+import { FolderMother } from '../../context/virtual-drive/folders/domain/FolderMother';
+import { Folder } from '../../../src/context/virtual-drive/folders/domain/Folder';
+
+// Mock the BackupsIPCRenderer module
+jest.mock('../../../src/apps/backups/BackupsIPCRenderer', () => ({
+  BackupsIPCRenderer: {
+    send: jest.fn(), // Mock the send method
+  },
+}));
+
+describe('Backup', () => {
+  let backup: Backup;
+  let localTreeBuilder: jest.Mocked<LocalTreeBuilder>;
+  let remoteTreeBuilder: jest.Mocked<RemoteTreeBuilder>;
+  let fileBatchUploader: jest.Mocked<FileBatchUploader>;
+  let fileBatchUpdater: jest.Mocked<FileBatchUpdater>;
+  let remoteFileDeleter: jest.Mocked<FileDeleter>;
+  let simpleFolderCreator: jest.Mocked<SimpleFolderCreator>;
+  let userAvaliableSpaceValidator: jest.Mocked<UserAvaliableSpaceValidator>;
+
+  beforeEach(() => {
+    localTreeBuilder = {
+      run: jest.fn(),
+      generator: jest.fn(),
+      traverse: jest.fn(),
+    } as unknown as jest.Mocked<LocalTreeBuilder>;
+
+    remoteTreeBuilder = {
+      run: jest.fn(),
+      generator: jest.fn(),
+      traverse: jest.fn(),
+    } as unknown as jest.Mocked<RemoteTreeBuilder>;
+
+    fileBatchUploader = {
+      run: jest.fn(),
+    } as unknown as jest.Mocked<FileBatchUploader>;
+
+    fileBatchUpdater = {
+      run: jest.fn(),
+      uploader: jest.fn(),
+      simpleFileOverrider: jest.fn(),
+    } as unknown as jest.Mocked<FileBatchUpdater>;
+    remoteFileDeleter = {
+      run: jest.fn(),
+    } as unknown as jest.Mocked<FileDeleter>;
+
+    userAvaliableSpaceValidator = {
+      run: jest.fn(),
+      repository: {},
+    } as unknown as jest.Mocked<UserAvaliableSpaceValidator>;
+
+    simpleFolderCreator = {
+      run: jest
+        .fn<Promise<Folder>, [string, number]>()
+        .mockImplementation((_path: string, _parentId: number) => {
+          return Promise.resolve(FolderMother.any() as Folder);
+        }),
+    } as unknown as jest.Mocked<SimpleFolderCreator>;
+
+    backup = new Backup(
+      localTreeBuilder,
+      remoteTreeBuilder,
+      fileBatchUploader,
+      fileBatchUpdater,
+      remoteFileDeleter,
+      simpleFolderCreator,
+      userAvaliableSpaceValidator
+    );
+
+    // Clear the mock before each test
+    (BackupsIPCRenderer.send as jest.Mock).mockClear();
+  });
+
+  it('should successfully run the backup process', async () => {
+    const info: BackupInfo = {
+      pathname: '/path/to/backup',
+      folderId: 123,
+      folderUuid: 'uuid',
+      tmpPath: '/tmp/path',
+      backupsBucket: 'backups-bucket',
+      name: 'backup-name',
+    };
+    const abortController = new AbortController();
+    const localTree = LocalTreeMother.oneLevel(10);
+    const remoteTree = RemoteTreeMother.oneLevel(10);
+
+    localTreeBuilder.run.mockResolvedValueOnce(right(localTree));
+    remoteTreeBuilder.run.mockResolvedValueOnce(remoteTree);
+    userAvaliableSpaceValidator.run.mockResolvedValueOnce(true);
+
+    const result = await backup.run(info, abortController);
+
+    expect(result).toBeUndefined();
+    expect(localTreeBuilder.run).toHaveBeenCalledWith(info.pathname);
+    expect(remoteTreeBuilder.run).toHaveBeenCalledWith(info.folderId);
+    expect(BackupsIPCRenderer.send).toHaveBeenCalled(); // Check if send was called
+  });
+
+  it('should return an error if local tree generation fails', async () => {
+    const info: BackupInfo = {
+      pathname: '/path/to/backup',
+      folderId: 123,
+      folderUuid: 'uuid',
+      tmpPath: '/tmp/path',
+      backupsBucket: 'backups-bucket',
+      name: 'backup-name',
+    };
+    const abortController = new AbortController();
+    const error = new DriveDesktopError(
+      'NOT_EXISTS',
+      'Failed to generate local tree'
+    );
+
+    localTreeBuilder.run.mockResolvedValueOnce(left(error));
+
+    const result = await backup.run(info, abortController);
+
+    expect(result).toBe(error);
+    expect(localTreeBuilder.run).toHaveBeenCalledWith(info.pathname);
+  });
+
+  it('should return an error if remote tree generation fails', async () => {
+    const info: BackupInfo = {
+      pathname: '/path/to/backup',
+      folderId: 123,
+      folderUuid: 'uuid',
+      tmpPath: '/tmp/path',
+      backupsBucket: 'backups-bucket',
+      name: 'backup-name',
+    };
+    const abortController = new AbortController();
+    const error = new DriveDesktopError(
+      'NOT_EXISTS',
+      'Failed to generate remote tree'
+    );
+
+    // Mock the behavior of dependencies
+    localTreeBuilder.run.mockResolvedValueOnce(
+      right(LocalTreeMother.oneLevel(10))
+    );
+    remoteTreeBuilder.run.mockResolvedValueOnce(
+      left(error) as unknown as Promise<RemoteTree>
+    );
+
+    const result = await backup.run(info, abortController);
+
+    expect(result).toStrictEqual(
+      new DriveDesktopError('UNKNOWN', 'An unknown error occurred')
+    );
+    expect(remoteTreeBuilder.run).toHaveBeenCalledWith(info.folderId);
+  });
+
+  it('should return an error if there is not enough space', async () => {
+    const info: BackupInfo = {
+      pathname: '/path/to/backup',
+      folderId: 123,
+      folderUuid: 'uuid',
+      tmpPath: '/tmp/path',
+      backupsBucket: 'backups-bucket',
+      name: 'backup-name',
+    };
+    const abortController = new AbortController();
+
+    localTreeBuilder.run.mockResolvedValueOnce(
+      right(LocalTreeMother.oneLevel(10))
+    );
+    remoteTreeBuilder.run.mockResolvedValueOnce(RemoteTreeMother.oneLevel(10));
+    userAvaliableSpaceValidator.run.mockResolvedValueOnce(false);
+
+    const result = await backup.run(info, abortController);
+
+    expect(result).toBeDefined();
+  });
+
+  it('should return an unknown error for unexpected issues', async () => {
+    const info: BackupInfo = {
+      pathname: '/path/to/backup',
+      folderId: 123,
+      folderUuid: 'uuid',
+      tmpPath: '/tmp/path',
+      backupsBucket: 'backups-bucket',
+      name: 'backup-name',
+    };
+    const abortController = new AbortController();
+
+    localTreeBuilder.run.mockImplementationOnce(() => {
+      throw new Error('Unexpected error');
+    });
+
+    const result = await backup.run(info, abortController);
+
+    expect(result).toBeInstanceOf(DriveDesktopError);
+    expect(result?.message).toBe('An unknown error occurred');
+  });
+});

--- a/tests/apps/backups/batches/AddedFilesBatchCreator.test.ts
+++ b/tests/apps/backups/batches/AddedFilesBatchCreator.test.ts
@@ -1,0 +1,31 @@
+import { AddedFilesBatchCreator } from '../../../../src/apps/backups/batches/AddedFilesBatchCreator';
+import { LocalFileSize } from '../../../../src/context/local/localFile/domain/LocalFileSize';
+import { LocalFileMother } from '../../../context/local/localFile/domain/LocalFileMother';
+
+describe('AddedFilesBatchCreator', () => {
+  it('should create batches of added files grouped by size', () => {
+    const localFileSmall = LocalFileMother.fromPartial({
+      size: LocalFileSize.MAX_SMALL_FILE_SIZE - 1,
+    });
+    const localFileMedium = LocalFileMother.fromPartial({
+      size: LocalFileSize.MAX_SMALL_FILE_SIZE + 1,
+    });
+    const localFileBig = LocalFileMother.fromPartial({
+      size: LocalFileSize.MAX_MEDIUM_FILE_SIZE + 1,
+    });
+
+    const files = [localFileSmall, localFileMedium, localFileBig];
+
+    const batches = AddedFilesBatchCreator.run(files);
+
+    expect(batches.length).toBe(3);
+
+    expect(batches[0]).toContain(localFileSmall);
+    expect(batches[1]).toContain(localFileMedium);
+    expect(batches[2]).toContain(localFileBig);
+
+    expect(batches[0].length).toBe(1);
+    expect(batches[1].length).toBe(1);
+    expect(batches[2].length).toBe(1);
+  });
+});

--- a/tests/apps/backups/batches/GroupFilesBySize.test.ts
+++ b/tests/apps/backups/batches/GroupFilesBySize.test.ts
@@ -1,0 +1,55 @@
+import { GroupFilesBySize } from '../../../../src/apps/backups/batches/GroupFilesBySize';
+import { LocalFileMother } from '../../../context/local/localFile/domain/LocalFileMother';
+import { LocalFileSize } from '../../../../src/context/local/localFile/domain/LocalFileSize';
+
+describe('GroupFilesBySize', () => {
+  it('should return an empty array when no files are provided', () => {
+    const groupedFiles = GroupFilesBySize.small([]); // Test for small files
+    expect(groupedFiles).toEqual([]);
+  });
+
+  it('should group only empty files', () => {
+    const emptyFile1 = LocalFileMother.fromPartial({ size: 0 });
+    const emptyFile2 = LocalFileMother.fromPartial({ size: 0 });
+
+    const groupedFiles = GroupFilesBySize.empty([emptyFile1, emptyFile2]);
+    expect(groupedFiles).toEqual([emptyFile1, emptyFile2]);
+  });
+
+  it('should group mixed file sizes correctly', () => {
+    const emptyFile = LocalFileMother.fromPartial({ size: 0 });
+    const smallFile = LocalFileMother.fromPartial({
+      size: LocalFileSize.MAX_SMALL_FILE_SIZE - 1,
+    });
+    const mediumFile = LocalFileMother.fromPartial({
+      size: LocalFileSize.MAX_SMALL_FILE_SIZE + 1,
+    });
+    const bigFile = LocalFileMother.fromPartial({
+      size: LocalFileSize.MAX_MEDIUM_FILE_SIZE + 1,
+    });
+
+    const files = [emptyFile, smallFile, mediumFile, bigFile];
+
+    const groupedSmallFiles = GroupFilesBySize.small(files);
+    const groupedMediumFiles = GroupFilesBySize.medium(files);
+    const groupedBigFiles = GroupFilesBySize.big(files);
+    const groupedEmptyFiles = GroupFilesBySize.empty(files);
+
+    expect(groupedSmallFiles).toEqual([smallFile]);
+    expect(groupedMediumFiles).toEqual([mediumFile]);
+    expect(groupedBigFiles).toEqual([bigFile]);
+    expect(groupedEmptyFiles).toEqual([emptyFile]);
+  });
+
+  it('should group all files of the same size correctly', () => {
+    const smallFile1 = LocalFileMother.fromPartial({
+      size: LocalFileSize.MAX_SMALL_FILE_SIZE - 1,
+    });
+    const smallFile2 = LocalFileMother.fromPartial({
+      size: LocalFileSize.MAX_SMALL_FILE_SIZE - 1,
+    });
+
+    const groupedFiles = GroupFilesBySize.small([smallFile1, smallFile2]);
+    expect(groupedFiles).toEqual([smallFile1, smallFile2]);
+  });
+});

--- a/tests/apps/backups/batches/GroupFilesInChunksBySize.test.ts
+++ b/tests/apps/backups/batches/GroupFilesInChunksBySize.test.ts
@@ -1,0 +1,43 @@
+import { GroupFilesInChunksBySize } from '../../../../src/apps/backups/batches/GroupFilesInChunksBySize';
+import { LocalFile } from '../../../../src/context/local/localFile/domain/LocalFile';
+import { LocalFileMother } from '../../../context/local/localFile/domain/LocalFileMother';
+
+describe('GroupFilesInChunksBySize', () => {
+  const generateFiles = (count: number): Array<LocalFile> => {
+    return Array.from({ length: count }, (_, i) =>
+      LocalFileMother.fromPartial({ size: i })
+    );
+  };
+
+  test('should group small files into 16 chunks', () => {
+    const files = generateFiles(32);
+    const chunks = GroupFilesInChunksBySize.small(files);
+    expect(chunks.length).toBe(2);
+    expect(chunks[0].length).toBe(16);
+    expect(chunks[1].length).toBe(16);
+  });
+
+  test('should group medium files into 6 chunks', () => {
+    const files = generateFiles(18);
+    const chunks = GroupFilesInChunksBySize.medium(files);
+    expect(chunks.length).toBe(3);
+    expect(chunks[0].length).toBe(6);
+    expect(chunks[1].length).toBe(6);
+    expect(chunks[2].length).toBe(6);
+  });
+
+  test('should group big files into 2 chunks', () => {
+    const files = generateFiles(4);
+    const chunks = GroupFilesInChunksBySize.big(files);
+    expect(chunks.length).toBe(2);
+    expect(chunks[0].length).toBe(2);
+    expect(chunks[1].length).toBe(2);
+  });
+
+  test('should group files into a single chunk when empty is called', () => {
+    const files = generateFiles(5);
+    const chunks = GroupFilesInChunksBySize.empty(files);
+    expect(chunks.length).toBe(1);
+    expect(chunks[0].length).toBe(5);
+  });
+});

--- a/tests/apps/backups/batches/ModifiedFilesBatchCreator.test.ts
+++ b/tests/apps/backups/batches/ModifiedFilesBatchCreator.test.ts
@@ -1,0 +1,45 @@
+import { ModifiedFilesBatchCreator } from '../../../../src/apps/backups/batches/ModifiedFilesBatchCreator';
+import { LocalFile } from '../../../../src/context/local/localFile/domain/LocalFile';
+import { LocalFileSize } from '../../../../src/context/local/localFile/domain/LocalFileSize';
+import { File } from '../../../../src/context/virtual-drive/files/domain/File';
+import { LocalFileMother } from '../../../context/local/localFile/domain/LocalFileMother';
+import { FileMother } from '../../../context/virtual-drive/files/domain/FileMother';
+describe('ModifiedFilesBatchCreator', () => {
+  it('should create batches of modified files grouped by size', () => {
+    const localFileSmall = LocalFileMother.fromPartial({
+      size: LocalFileSize.MAX_SMALL_FILE_SIZE - 1,
+    });
+    const localFileMedium = LocalFileMother.fromPartial({
+      size: LocalFileSize.MAX_SMALL_FILE_SIZE + 1,
+    });
+    const localFileBig = LocalFileMother.fromPartial({
+      size: LocalFileSize.MAX_MEDIUM_FILE_SIZE + 1,
+    });
+
+    const smallFile = FileMother.fromPartial({});
+    const mediumFile = FileMother.fromPartial({});
+    const bigFile = FileMother.fromPartial({});
+
+    const files = new Map<LocalFile, File>([
+      [localFileSmall, smallFile],
+      [localFileMedium, mediumFile],
+      [localFileBig, bigFile],
+    ]);
+
+    const batches = ModifiedFilesBatchCreator.run(files);
+
+    expect(batches.length).toBe(3);
+
+    expect(batches[0].get(localFileSmall)).toBeDefined();
+    expect(batches[1].get(localFileMedium)).toBeDefined();
+    expect(batches[2].get(localFileBig)).toBeDefined();
+
+    expect(batches[0].size).toBe(1);
+    expect(batches[1].size).toBe(1);
+    expect(batches[2].size).toBe(1);
+
+    expect(batches[0].get(localFileSmall)).toBe(smallFile);
+    expect(batches[1].get(localFileMedium)).toBe(mediumFile);
+    expect(batches[2].get(localFileBig)).toBe(bigFile);
+  });
+});

--- a/tests/apps/backups/diff/FoldersDiffCalculator.test.ts
+++ b/tests/apps/backups/diff/FoldersDiffCalculator.test.ts
@@ -1,6 +1,9 @@
 import { FoldersDiffCalculator } from '../../../../src/apps/backups/diff/FoldersDiffCalculator';
 import { LocalTreeMother } from '../../../context/local/tree/domain/LocalTreeMother';
 import { RemoteTreeMother } from '../../../context/virtual-drive/tree/domain/RemoteTreeMother';
+import { LocalFolderMother } from '../../../context/local/localFolder/domain/LocalFolderMother';
+import { AbsolutePathMother } from '../../../context/shared/infrastructure/AbsolutePathMother';
+import { DateMother } from '../../../context/shared/domain/DateMother';
 
 describe('FoldersDiffCalculator', () => {
   it('groups folders as added when not found on the remote tree', () => {
@@ -31,5 +34,58 @@ describe('FoldersDiffCalculator', () => {
 
     expect(deleted.length).toBe(expectedNumberOfFoldersToDelete);
     expect(deleted).toStrictEqual(remoteFoldersWithoutRoot);
+  });
+
+  it('identifies unmodified folders correctly', () => {
+    const expectedNumberOfUnmodifiedFolders = 10;
+    const local = LocalTreeMother.oneLevel(expectedNumberOfUnmodifiedFolders);
+    const remote = RemoteTreeMother.cloneFromLocal(local);
+
+    const { unmodified } = FoldersDiffCalculator.calculate(local, remote);
+
+    expect(unmodified.length).toBe(expectedNumberOfUnmodifiedFolders + 1);
+    expect(unmodified).toStrictEqual(local.folders);
+  });
+
+  it('handles mixed additions, deletions, and unmodified folders', () => {
+    const expectedNumberOfUnmodifiedFolders = 10;
+    const expectedNumberOfAddedFolders = 5;
+
+    const local = LocalTreeMother.oneLevel(expectedNumberOfUnmodifiedFolders);
+    const originalRemote = RemoteTreeMother.cloneFromLocal(local);
+
+    const newFolders = [
+      LocalFolderMother.fromPartial({
+        path: AbsolutePathMother.anyFile(),
+        modificationTime: DateMother.today().getTime(),
+      }),
+      LocalFolderMother.fromPartial({
+        path: AbsolutePathMother.anyFile(),
+        modificationTime: DateMother.today().getTime(),
+      }),
+      LocalFolderMother.fromPartial({
+        path: AbsolutePathMother.anyFile(),
+        modificationTime: DateMother.today().getTime(),
+      }),
+      LocalFolderMother.fromPartial({
+        path: AbsolutePathMother.anyFile(),
+        modificationTime: DateMother.today().getTime(),
+      }),
+      LocalFolderMother.fromPartial({
+        path: AbsolutePathMother.anyFile(),
+        modificationTime: DateMother.today().getTime(),
+      }),
+    ];
+
+    newFolders.forEach((folder) => local.addFolder(local.root, folder));
+
+    const { added, deleted, unmodified } = FoldersDiffCalculator.calculate(
+      local,
+      originalRemote
+    );
+
+    expect(added.length).toBe(expectedNumberOfAddedFolders);
+    expect(deleted.length).toBe(0);
+    expect(unmodified.length).toBe(expectedNumberOfUnmodifiedFolders + 1);
   });
 });

--- a/tests/apps/backups/index.test.ts
+++ b/tests/apps/backups/index.test.ts
@@ -1,0 +1,158 @@
+import { jest } from '@jest/globals';
+import { Backup } from '../../../src/apps/backups/Backup';
+import { BackupsIPCRenderer } from '../../../src/apps/backups/BackupsIPCRenderer';
+import { BackupsDependencyContainerFactory } from '../../../src/apps/backups/dependency-injection/BackupsDependencyContainerFactory';
+import { DriveDesktopError } from '../../../src/context/shared/domain/errors/DriveDesktopError';
+import { backupFolder } from '../../../src/apps/backups/index'; // Ensure this is imported
+import { BackUpErrorCauseEnum } from '../../../src/apps/backups/BackupError';
+
+interface BackupInfo {
+  folderId: number;
+  path: string;
+  parentId: number;
+  name: string;
+}
+
+jest.mock('electron', () => ({
+  ipcRenderer: {
+    on: jest.fn(),
+    send: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/apps/backups/BackupsIPCRenderer', () => ({
+  BackupsIPCRenderer: {
+    invoke: jest.fn<Promise<BackupInfo>, []>().mockResolvedValue({
+      folderId: 123,
+      path: 'test/path',
+      parentId: 456,
+      name: 'test',
+    }),
+    send: jest.fn(),
+    on: jest.fn(),
+  },
+}));
+
+(global as any).window = {
+  addEventListener: jest.fn(),
+};
+
+function createMockBackup(): jest.Mocked<Backup> {
+  return {
+    run: jest.fn<
+      Promise<DriveDesktopError | undefined>,
+      [BackupInfo, AbortController]
+    >(),
+  } as unknown as jest.Mocked<Backup>;
+}
+
+jest.mock(
+  '../../../src/apps/backups/dependency-injection/BackupsDependencyContainerFactory',
+  () => ({
+    BackupsDependencyContainerFactory: {
+      build: jest.fn<Promise<unknown>, []>().mockResolvedValue({
+        get: jest.fn().mockImplementation((service) => {
+          if (service === Backup) {
+            return createMockBackup();
+          }
+          return undefined;
+        }),
+      }),
+      reinitialize: jest.fn(),
+    },
+  })
+);
+
+describe('Backup Functionality', () => {
+  let backup: jest.Mocked<Backup>;
+
+  beforeEach(() => {
+    backup = {
+      run: jest.fn(),
+    } as unknown as jest.Mocked<Backup>;
+
+    (BackupsDependencyContainerFactory.build as jest.Mock).mockResolvedValue({
+      get: jest.fn().mockReturnValue(backup),
+    });
+
+    (BackupsIPCRenderer.invoke as jest.Mock).mockResolvedValue({
+      folderId: 123,
+      path: 'test/path',
+      parentId: 456,
+      name: 'test',
+    });
+
+    global.window = Object.create(window);
+    Object.defineProperty(window, 'dispatchEvent', {
+      value: jest.fn(),
+      writable: true,
+    });
+    Object.defineProperty(window, 'addEventListener', {
+      value: jest.fn(),
+      writable: true,
+    });
+  });
+
+  it('should complete the backup process successfully', async () => {
+    backup.run.mockResolvedValueOnce(undefined);
+
+    await backupFolder();
+
+    expect(BackupsIPCRenderer.send).toHaveBeenCalledWith(
+      'backups.backup-completed',
+      123
+    );
+  });
+
+  it('should handle offline event', async () => {
+    const abortController = {
+      signal: {
+        aborted: false,
+        addEventListener: jest.fn(),
+      },
+      abort: jest.fn(() => {
+        abortController.signal.aborted = true;
+      }),
+    };
+
+    jest
+      .spyOn(window, 'addEventListener')
+      .mockImplementation((event, callback) => {
+        if (event === 'offline' && typeof callback === 'function') {
+          callback(new Event('offline'));
+        }
+      });
+
+    backup.run.mockResolvedValueOnce(undefined);
+
+    await backupFolder();
+
+    window.dispatchEvent(new Event('offline'));
+
+    expect(BackupsIPCRenderer.send).toHaveBeenCalledWith(
+      'backups.backup-failed',
+      123,
+      BackUpErrorCauseEnum.NO_INTERNET
+    );
+  });
+
+  it('should handle abort event', async () => {
+    jest.useFakeTimers();
+
+    const abortController = new AbortController();
+    backup.run.mockResolvedValueOnce(undefined);
+
+    await backupFolder();
+
+    BackupsIPCRenderer.on('backups.abort', () => {
+      abortController.abort();
+    });
+
+    jest.advanceTimersByTime(500);
+
+    // @ts-ignore as the event is only defined in the renderer
+    BackupsIPCRenderer.send('backups.abort');
+
+    expect(BackupsIPCRenderer.send).toHaveBeenCalledWith('backups.abort');
+  });
+});

--- a/tests/apps/backups/utils/relative.test.ts
+++ b/tests/apps/backups/utils/relative.test.ts
@@ -1,0 +1,27 @@
+import { relative } from '../../../../src/apps/backups/utils/relative';
+
+describe('relative', () => {
+  it('should return the relative path when the target is a subdirectory of the root', () => {
+    const root = '/home/user/projects';
+    const target = '/home/user/projects/my-app/src';
+    const expected = '/my-app/src';
+
+    expect(relative(root, target)).toBe(expected);
+  });
+
+  it('should return a single slash when the root and target are the same', () => {
+    const root = '/home/user/projects';
+    const target = '/home/user/projects';
+    const expected = '/';
+
+    expect(relative(root, target)).toBe(expected);
+  });
+
+  it('should handle paths with trailing slashes correctly', () => {
+    const root = '/home/user/projects/';
+    const target = '/home/user/projects/my-app/src/';
+    const expected = '/my-app/src';
+
+    expect(relative(root, target)).toBe(expected);
+  });
+});

--- a/tests/context/virtual-drive/files/application/FileCreator.test.ts
+++ b/tests/context/virtual-drive/files/application/FileCreator.test.ts
@@ -11,6 +11,7 @@ import { FileSyncNotifierMock } from '../__mocks__/FileSyncNotifierMock';
 import { RemoteFileSystemMock } from '../__mocks__/RemoteFileSystemMock';
 import { FileMother } from '../domain/FileMother';
 import { FileSizeMother } from '../domain/FileSizeMother';
+import { right } from '../../../../../src/context/shared/domain/Either';
 
 describe('File Creator', () => {
   let remoteFileSystemMock: RemoteFileSystemMock;
@@ -49,11 +50,11 @@ describe('File Creator', () => {
       contentsId: contentsId.value,
     }).attributes();
 
-    fileRepository.addMock.mockImplementationOnce(() => {
-      // returns Promise<void>
-    });
+    fileRepository.addMock.mockImplementationOnce(() => Promise.resolve());
 
-    remoteFileSystemMock.persistMock.mockResolvedValueOnce(fileAttributes);
+    remoteFileSystemMock.persistMock.mockResolvedValueOnce(
+      right(fileAttributes)
+    );
 
     await SUT.run(path.value, contentsId.value, size.value);
 
@@ -73,11 +74,11 @@ describe('File Creator', () => {
       contentsId: contentsId.value,
     }).attributes();
 
-    fileRepository.addMock.mockImplementationOnce(() => {
-      // returns Promise<void>
-    });
+    fileRepository.addMock.mockImplementationOnce(() => Promise.resolve());
 
-    remoteFileSystemMock.persistMock.mockResolvedValueOnce(fileAttributes);
+    remoteFileSystemMock.persistMock.mockResolvedValueOnce(
+      right(fileAttributes)
+    );
 
     await SUT.run(path.value, contentsId.value, size.value);
 
@@ -107,11 +108,11 @@ describe('File Creator', () => {
       .spyOn(fileDeleter, 'run')
       .mockResolvedValueOnce(Promise.resolve());
 
-    remoteFileSystemMock.persistMock.mockResolvedValueOnce(fileAttributes);
+    remoteFileSystemMock.persistMock.mockResolvedValueOnce(
+      right(fileAttributes)
+    );
 
-    fileRepository.addMock.mockImplementationOnce(() => {
-      // returns Promise<void>
-    });
+    fileRepository.addMock.mockImplementationOnce(() => Promise.resolve());
 
     await SUT.run(path.value, contentsId.value, size.value);
 

--- a/tests/context/virtual-drive/folders/__mocks__/FolderRemoteFileSystemMock.ts
+++ b/tests/context/virtual-drive/folders/__mocks__/FolderRemoteFileSystemMock.ts
@@ -1,4 +1,4 @@
-import { Either } from '../../../../../src/context/shared/domain/Either';
+import { Either, right } from '../../../../../src/context/shared/domain/Either';
 import { Folder } from '../../../../../src/context/virtual-drive/folders/domain/Folder';
 import { FolderId } from '../../../../../src/context/virtual-drive/folders/domain/FolderId';
 import { FolderPath } from '../../../../../src/context/virtual-drive/folders/domain/FolderPath';
@@ -66,13 +66,15 @@ export class FolderRemoteFileSystemMock implements RemoteFileSystem {
       includeUuid ? new FolderUuid(folder.uuid) : undefined
     );
 
-    this.persistMock.mockResolvedValueOnce({
-      id: folder.id,
-      uuid: folder.uuid,
-      createdAt: folder.createdAt.toISOString(),
-      updatedAt: folder.updatedAt.toISOString(),
-      parentId: folder.parentId as number,
-    } satisfies FolderPersistedDto);
+    this.persistMock.mockResolvedValueOnce(
+      right({
+        id: folder.id,
+        uuid: folder.uuid,
+        createdAt: folder.createdAt.toISOString(),
+        updatedAt: folder.updatedAt.toISOString(),
+        parentId: folder.parentId as number,
+      } satisfies FolderPersistedDto)
+    );
   }
 
   shouldTrash(folder: Folder, error?: Error) {

--- a/tests/context/virtual-drive/tree/domain/RemoteTreeMother.ts
+++ b/tests/context/virtual-drive/tree/domain/RemoteTreeMother.ts
@@ -1,10 +1,11 @@
-import path from 'path';
+import path, { relative } from 'path';
 import { FolderStatus } from '../../../../../src/context/virtual-drive/folders/domain/FolderStatus';
 import { RemoteTree } from '../../../../../src/context/virtual-drive/remoteTree/domain/RemoteTree';
 import { FileNameMother } from '../../../shared/domain/FileNameMother';
 import { FileMother } from '../../files/domain/FileMother';
 import { FolderMother } from '../../folders/domain/FolderMother';
 import { FolderNameMother } from '../../../shared/domain/FolderNameMother';
+import { LocalTree } from '../../../../../src/context/local/localTree/domain/LocalTree';
 
 export class RemoteTreeMother {
   static onlyRoot(): RemoteTree {
@@ -38,5 +39,39 @@ export class RemoteTreeMother {
     }
 
     return tree;
+  }
+
+  static cloneFromLocal(local: LocalTree): RemoteTree {
+    const remote = RemoteTreeMother.onlyRoot();
+
+    local.files.forEach((file) =>
+      remote.addFile(
+        remote.root,
+        FileMother.fromPartial({
+          path: path.join(
+            remote.root.path,
+            relative(local.root.path, file.path)
+          ),
+        })
+      )
+    );
+
+    local.folders.forEach((folder) => {
+      if (folder.path === local.root.path) {
+        return;
+      }
+
+      remote.addFolder(
+        remote.root,
+        FolderMother.fromPartial({
+          path: path.join(
+            remote.root.path,
+            relative(local.root.path, folder.path)
+          ),
+        })
+      );
+    });
+
+    return remote;
   }
 }

--- a/tests/onboarding.e2e.ts
+++ b/tests/onboarding.e2e.ts
@@ -26,7 +26,7 @@ test.describe('onboarding', () => {
       ipcMainEmit(electronApp, 'open-onboarding-window');
       const newPage = await electronApp.firstWindow();
       expect(newPage).toBeTruthy();
-      expect(await newPage.title()).toBe('Internxt Drive');
+      expect(await newPage.title()).toBe('Internxt');
       page = newPage;
     });
   });


### PR DESCRIPTION
## Key Changes

1. **Branding Updates:**
   - Updated the application name from "Internxt Drive" to "Internxt" across various files, including `package.json`, UI components, and localization files.

2. **Unit tests:**
   - Fixed old tests that were now failing, causing noise during testing.
   - Improved test coverage across backup functionality including file grouping, error handling, and the backup process.

3. **Network Connectivity:**
   - Implemented network status checks using the `isOnline` utility to provide real-time feedback on connectivity issues.

5. **Miscellaneous:**
   - Increased the `BucketEntry` maximum size limit from 20 GB to 40GB.
   - Fixed a bug that prevented files bigger than 5GB to be synced or backed up.