### PR TITLE
[PB-3633]:Sync doesn't work

### DIFF
--- a/src/context/virtual-drive/folders/application/FolderDeleter.ts
+++ b/src/context/virtual-drive/folders/application/FolderDeleter.ts
@@ -44,7 +44,7 @@ export class FolderDeleter {
       folder.trash();
 
       await this.remote.trash(folder.id);
-      await this.repository.update(folder);
+      await this.repository.delete(folder.id);
     } catch (error: unknown) {
       Logger.error(`Error deleting the folder ${folder.name}: `, error);
 

--- a/tests/context/virtual-drive/folders/application/FolderDeleter.test.ts
+++ b/tests/context/virtual-drive/folders/application/FolderDeleter.test.ts
@@ -40,6 +40,7 @@ describe('Folder deleter', () => {
       .mockResolvedValueOnce(true);
 
     await SUT.run(folder.uuid);
+    expect(repository.deleteMock).toBeCalledWith(folder.id);
   });
 
   it('throws an error when trashing a folder already trashed', async () => {


### PR DESCRIPTION
## What is changed
The folder deleter now deletes the Folder properly, also I updated the test because it was not asserting anything previously.

## Why
I was able to reproduce the bug (In the production environment thought, not locally) in which, if you add a folder to the drive with files and subfolders, wait to sync and delete it, the folder would appear and you could not delete it properly, I found out that the delete part of the FolderDeleter service was missing.