### PR TITLE
fix: unreliable network status

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,3 @@
+## What is Changed / Added
+----
+## Why

--- a/src/apps/main/main.ts
+++ b/src/apps/main/main.ts
@@ -56,6 +56,7 @@ import { Theme } from '../shared/types/Theme';
 import { installNautilusExtension } from './nautilus-extension/install';
 import { uninstallNautilusExtension } from './nautilus-extension/uninstall';
 import { setUpBackups } from './background-processes/backups/setUpBackups';
+import dns from 'node:dns';
 
 let mainWindow: Electron.BrowserWindow;
 
@@ -195,4 +196,14 @@ ipcMain.handle('request-reinitialize-backups', async () => {
     mainWindow.webContents.send('reinitialize-backups');
   }
   return 'Reinitialization requested';
+});
+
+ipcMain.handle('check-internet-connection', async () => {
+  return new Promise((resolve) => {
+    dns.lookup('google.com', (err) => {
+      resolve(!err);
+    });
+
+    setTimeout(() => resolve(false), 3000);
+  });
 });

--- a/src/apps/main/preload.d.ts
+++ b/src/apps/main/preload.d.ts
@@ -47,6 +47,8 @@ declare interface Window {
 
     isUserLoggedIn(): Promise<boolean>;
 
+    checkInternetConnection(): Promise<boolean>;
+
     onUserLoggedInChanged(func: (value: boolean) => void): void;
 
     logout(): void;

--- a/src/apps/main/preload.js
+++ b/src/apps/main/preload.js
@@ -28,6 +28,9 @@ contextBridge.exposeInMainWorld('electron', {
   isUserLoggedIn() {
     return ipcRenderer.invoke('is-user-logged-in');
   },
+  checkInternetConnection() {
+    return ipcRenderer.invoke('check-internet-connection');
+  },
   onUserLoggedInChanged(func) {
     return ipcRenderer.on('user-logged-in-changed', (_, v) => func(v));
   },

--- a/src/apps/renderer/hooks/useOnlineStatus/useOnlineStatus.test.ts
+++ b/src/apps/renderer/hooks/useOnlineStatus/useOnlineStatus.test.ts
@@ -1,0 +1,178 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useOnlineStatus } from './useOnlineStatus';
+
+describe('useOnlineStatus', () => {
+  beforeAll(() => {
+    global.window = global as any;
+
+    global.window.electron = {
+      checkInternetConnection: jest.fn().mockResolvedValue(true),
+    } as unknown as typeof window.electron;
+    global.window.addEventListener = jest.fn();
+    global.window.removeEventListener = jest.fn();
+
+    global.navigator = {
+      onLine: false,
+    } as unknown as Navigator;
+  });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  it('should return true when online', async () => {
+    jest
+      .spyOn(window.electron, 'checkInternetConnection')
+      .mockResolvedValue(true);
+
+    const { result } = renderHook(() => useOnlineStatus(1000));
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('should return false when offline', async () => {
+    jest
+      .spyOn(window.electron, 'checkInternetConnection')
+      .mockResolvedValue(false);
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useOnlineStatus(1000)
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await waitForNextUpdate();
+
+    expect(result.current).toBe(false);
+  });
+
+  it('should return true when online after being offline', async () => {
+    const checkInternetConnectionMock = jest.spyOn(
+      window.electron,
+      'checkInternetConnection'
+    );
+    checkInternetConnectionMock.mockResolvedValue(false);
+
+    const { rerender, result, waitForNextUpdate } = renderHook(() =>
+      useOnlineStatus(1000)
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await waitForNextUpdate();
+    expect(result.current).toBe(false);
+
+    checkInternetConnectionMock.mockResolvedValue(true);
+    rerender();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    await waitForNextUpdate();
+
+    expect(result.current).toBe(true);
+  });
+
+  it('should use navigator.onLine as fallback if checkInternetConnection fails', async () => {
+    const checkInternetConnectionMock = jest.spyOn(
+      window.electron,
+      'checkInternetConnection'
+    );
+
+    checkInternetConnectionMock.mockRejectedValue(new Error('IPC failed'));
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useOnlineStatus(1000)
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await waitForNextUpdate();
+
+    expect(result.current).toBe(false);
+  });
+
+  it('should clean up event listeners on unmount', () => {
+    const addEventListenerMock = jest.spyOn(window, 'addEventListener');
+    const removeEventListenerMock = jest.spyOn(window, 'removeEventListener');
+
+    const { unmount } = renderHook(() => useOnlineStatus(1000));
+
+    expect(addEventListenerMock).toHaveBeenCalledWith(
+      'online',
+      expect.any(Function)
+    );
+    expect(addEventListenerMock).toHaveBeenCalledWith(
+      'offline',
+      expect.any(Function)
+    );
+
+    unmount();
+
+    expect(removeEventListenerMock).toHaveBeenCalledWith(
+      'online',
+      expect.any(Function)
+    );
+    expect(removeEventListenerMock).toHaveBeenCalledWith(
+      'offline',
+      expect.any(Function)
+    );
+  });
+
+  it('should respect the custom interval time', async () => {
+    const checkInternetConnectionMock = jest.spyOn(
+      window.electron,
+      'checkInternetConnection'
+    );
+    checkInternetConnectionMock.mockResolvedValue(true);
+
+    const INTERVAL = 5000;
+    renderHook(() => useOnlineStatus(INTERVAL));
+
+    act(() => {
+      jest.advanceTimersByTime(4000);
+    });
+
+    expect(checkInternetConnectionMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(checkInternetConnectionMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('should update state only when checkInternetConnection returns a different value', async () => {
+    const checkInternetConnectionMock = jest.spyOn(
+      window.electron,
+      'checkInternetConnection'
+    );
+
+    checkInternetConnectionMock.mockResolvedValue(true);
+
+    const { result } = renderHook(() => useOnlineStatus(1000));
+
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(checkInternetConnectionMock).toHaveBeenCalledTimes(4);
+    expect(result.current).toBe(true);
+  });
+});

--- a/src/apps/renderer/hooks/useOnlineStatus/useOnlineStatus.ts
+++ b/src/apps/renderer/hooks/useOnlineStatus/useOnlineStatus.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+
+/** Default is 5 minutes that is equal to 300000 ms  */
+const DEFAULT_INTERVAL = 300000;
+
+export const useOnlineStatus = (INTERVAL = DEFAULT_INTERVAL) => {
+  const [online, setOnline] = useState(true);
+
+  async function checkInternetConnection(): Promise<boolean> {
+    try {
+      return await window.electron.checkInternetConnection();
+    } catch {
+      return navigator.onLine;
+    }
+  }
+
+  useEffect(() => {
+    const updateOnlineStatus = async () => {
+      const onlineStatus = await checkInternetConnection();
+      setOnline(onlineStatus);
+    };
+
+    void updateOnlineStatus();
+
+    window.addEventListener('online', updateOnlineStatus);
+    window.addEventListener('offline', updateOnlineStatus);
+
+    const statusInterval = setInterval(updateOnlineStatus, INTERVAL);
+
+    return () => {
+      window.removeEventListener('online', updateOnlineStatus);
+      window.removeEventListener('offline', updateOnlineStatus);
+      clearInterval(statusInterval);
+    };
+  }, []);
+
+  return online;
+};

--- a/src/apps/renderer/pages/Widget/SyncAction.tsx
+++ b/src/apps/renderer/pages/Widget/SyncAction.tsx
@@ -1,5 +1,5 @@
 import { CheckCircle, XCircle } from '@phosphor-icons/react';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { SyncStatus } from '../../../../context/desktop/sync/domain/SyncStatus';
 import Spinner from '../../assets/spinner.svg';
 import Button from '../../components/Button';
@@ -7,12 +7,11 @@ import { useTranslationContext } from '../../context/LocalContext';
 import useVirtualDriveStatus from '../../hooks/useVirtualDriveStatus';
 import useSyncStatus from '../../hooks/useSyncStatus';
 import useUsage from '../../hooks/useUsage';
-import isOnline from '../../../utils/is-online';
+import { useOnlineStatus } from '../../hooks/useOnlineStatus/useOnlineStatus';
 
 export default function SyncAction(props: { syncStatus: SyncStatus }) {
   const { translate } = useTranslationContext();
-
-  const [isOnLine, setIsOnLine] = useState(true);
+  const isOnLine = useOnlineStatus();
   const { usage, status } = useUsage();
   const { virtualDriveStatus } = useVirtualDriveStatus();
   const { syncStatus } = useSyncStatus();
@@ -29,26 +28,6 @@ export default function SyncAction(props: { syncStatus: SyncStatus }) {
       reportError(error);
     }
   };
-
-  useEffect(() => {
-    const updateOnlineStatus = async () => {
-      const online = await isOnline();
-      setIsOnLine(online);
-    };
-
-    updateOnlineStatus();
-
-    const intervalId = setInterval(updateOnlineStatus, 60000 * 5);
-
-    window.addEventListener('online', updateOnlineStatus);
-    window.addEventListener('offline', updateOnlineStatus);
-
-    return () => {
-      clearInterval(intervalId);
-      window.removeEventListener('online', updateOnlineStatus);
-      window.removeEventListener('offline', updateOnlineStatus);
-    };
-  }, []);
 
   useEffect(() => {
     if (!isOnLine) {


### PR DESCRIPTION
## What is Changed / Added
Added a custom hook that checks periodically the network status  via a ipc event

----
## Why
The code responsible for the network status was quite unreliable, specially while developing, causing issues like the following screenshoots
![image](https://github.com/user-attachments/assets/22f93673-9700-4238-9917-8579b39ce975)
or unexpected notifications
