### PR TITLE
[PB-3877]: fix/sync issue

### DIFF
--- a/src/apps/main/remote-sync/RemoteSyncErrorHandler/RemoteSyncErrorHandler.test.ts
+++ b/src/apps/main/remote-sync/RemoteSyncErrorHandler/RemoteSyncErrorHandler.test.ts
@@ -1,0 +1,151 @@
+import { RemoteSyncErrorHandler, syncItemType } from './RemoteSyncErrorHandler';
+import { RemoteSyncError, RemoteSyncNetworkError, RemoteSyncServerError } from '../errors';
+import { addVirtualDriveIssue } from '../../issues/virtual-drive';
+import { reportError } from '../../bug-report/service';
+import { VirtualDriveIssue } from '../../../../shared/issues/VirtualDriveIssue';
+
+jest.mock('electron-log');
+
+jest.mock('../../issues/virtual-drive', () => ({
+  addVirtualDriveIssue: jest.fn()
+}));
+
+jest.mock('../../bug-report/service', () => ({
+  reportError: jest.fn()
+}));
+
+describe('RemoteSyncErrorHandler', () => {
+  let sut: RemoteSyncErrorHandler;
+
+  beforeEach(() => {
+    sut = new RemoteSyncErrorHandler();
+    jest.clearAllMocks();
+  });
+
+  describe('handleSyncError ', () => {
+    it('should handle properly a type RemoteSyncNetworkError', () => {
+      const networkError = new RemoteSyncNetworkError('Test error');
+      const syncType: syncItemType = 'files';
+      const itemName = 'Test File';
+      const checkpoint = new Date('2025-02-24');
+      const handleNetworkErrorSpy = jest.spyOn(sut, 'handleNetworkError');
+      const reportErrorToSentrySpy = jest.spyOn(sut, 'reportErrorToSentry');
+
+      sut.handleSyncError(networkError, syncType, itemName, checkpoint);
+
+      expect(handleNetworkErrorSpy).toHaveBeenCalledWith(networkError, syncType, itemName);
+      expect(reportErrorToSentrySpy).toHaveBeenCalledWith(networkError, syncType, checkpoint);
+      expect(addVirtualDriveIssue).toHaveBeenCalled();
+    });
+
+    it('should handle properly a type RemoteSyncServerError', () => {
+      const serverError = new RemoteSyncServerError(500, { message: 'Server error occurred' });
+      const syncType: syncItemType = 'folders';
+      const itemName = 'Test Folder';
+      const checkpoint = new Date('2025-02-24');
+      const handleServerErrorSpy = jest.spyOn(sut, 'handleServerError');
+      const reportErrorToSentrySpy = jest.spyOn(sut, 'reportErrorToSentry');
+
+      sut.handleSyncError(serverError, syncType, itemName, checkpoint);
+
+      expect(handleServerErrorSpy).toHaveBeenCalledWith(serverError, syncType, itemName);
+      expect(reportErrorToSentrySpy).toHaveBeenCalledWith(serverError, syncType, checkpoint);
+      expect(addVirtualDriveIssue).toHaveBeenCalled();
+    });
+
+    it('should handle properly the default type RemoteSyncError', () => {
+      const genericError = new RemoteSyncError('Test generic error');
+      const syncType: syncItemType = 'files';
+      const itemName = 'Test File';
+      const checkpoint = new Date('2025-02-24');
+      const handleRemoteSyncErrorSpy = jest.spyOn(sut, 'handleRemoteSyncError');
+      const reportErrorToSentrySpy = jest.spyOn(sut, 'reportErrorToSentry');
+
+      sut.handleSyncError(genericError, syncType, itemName, checkpoint);
+
+      expect(handleRemoteSyncErrorSpy).toHaveBeenCalledWith(genericError, syncType, itemName);
+      expect(reportErrorToSentrySpy).toHaveBeenCalledWith(genericError, syncType, checkpoint);
+      expect(addVirtualDriveIssue).toHaveBeenCalled();
+    });
+
+    it('should properly report error to sentry', () => {
+      const genericError = new RemoteSyncError('Test generic error');
+      const syncType: syncItemType = 'files';
+      const itemName = 'Test File';
+      const checkpoint = new Date('2025-02-24');
+      const reportErrorToSentrySpy = jest.spyOn(sut, 'reportErrorToSentry');
+
+      sut.handleSyncError(genericError, syncType, itemName, checkpoint);
+
+      expect(reportErrorToSentrySpy).toHaveBeenCalledWith(genericError, syncType, checkpoint);
+    });
+  });
+
+  describe('handleSyncErrorWithIssue', () => {
+    it('should properly add a virtual drive issue', () => {
+      const genericError = new RemoteSyncError('Test generic error');
+      const syncType: syncItemType = 'files';
+      const errorDetail = {
+        errorLabel: 'Test error label',
+        issue: {
+          error: 'UPLOAD_ERROR',
+          cause: 'NO_INTERNET',
+          name: 'Test File'
+        } as VirtualDriveIssue
+      };
+
+      const issues: Record<syncItemType, VirtualDriveIssue> = {
+        files: {
+          error: 'UPLOAD_ERROR',
+          cause: 'NO_INTERNET',
+          name: 'Test File'
+        },
+        folders: {
+          error: 'UPLOAD_ERROR',
+          cause: 'NO_INTERNET',
+          name: 'Test Folder'
+        }
+      };
+
+      sut.handleSyncErrorWithIssue(genericError, syncType, errorDetail);
+
+      expect(addVirtualDriveIssue).toHaveBeenCalledWith(issues[syncType]);
+    });
+  });
+
+  describe('reportErrorToSentry', () => {
+    it('should call reportError with a valid "lastFilesSyncAt" properly', () => {
+      const error = new RemoteSyncError('Test error');
+      const syncType: syncItemType = 'files';
+      const checkpoint = new Date('2025-02-24');
+
+      sut.reportErrorToSentry(error, syncType, checkpoint);
+
+      expect(reportError).toHaveBeenCalledWith(error, {
+        lastFilesSyncAt: checkpoint.toISOString(),
+      });
+    });
+
+    it('should call reportError with "INITIAL_FILES_SYNC" when syncItemType is "files" and no checkpoint is provided', () => {
+      const error = new RemoteSyncError('Test error');
+      const syncType: syncItemType = 'files';
+
+      sut.reportErrorToSentry(error, syncType);
+
+      expect(reportError).toHaveBeenCalledWith(error, {
+        lastFilesSyncAt: 'INITIAL_FILES_SYNC',
+      });
+    });
+
+    it('should call reportError with "INITIAL_FOLDERS_SYNC" when syncItemType is "folders" and no checkpoint is provided', () => {
+      const error = new RemoteSyncError('Test error');
+      const syncType: syncItemType = 'folders';
+
+      sut.reportErrorToSentry(error, syncType);
+
+      expect(reportError).toHaveBeenCalledWith(error, {
+        lastFoldersSyncAt: 'INITIAL_FOLDERS_SYNC',
+      });
+    });
+  });
+});

--- a/src/apps/main/remote-sync/RemoteSyncErrorHandler/RemoteSyncErrorHandler.ts
+++ b/src/apps/main/remote-sync/RemoteSyncErrorHandler/RemoteSyncErrorHandler.ts
@@ -1,0 +1,147 @@
+import {
+  RemoteSyncError,
+  RemoteSyncInvalidResponseError,
+  RemoteSyncNetworkError,
+  RemoteSyncServerError,
+} from '../errors';
+import Logger from 'electron-log';
+import { addVirtualDriveIssue } from '../../issues/virtual-drive';
+import { VirtualDriveIssue } from '../../../../shared/issues/VirtualDriveIssue';
+import { reportError } from '../../bug-report/service';
+
+export type syncItemType = 'files' | 'folders';
+
+export interface VirtualDriveIssueByType {
+  files: VirtualDriveIssue;
+  folders: VirtualDriveIssue;
+}
+
+export class RemoteSyncErrorHandler {
+  public handleSyncError(
+    error: RemoteSyncError,
+    syncItemType: syncItemType,
+    itemName: string,
+    itemCheckpoint?: Date
+  ): void {
+    switch (true) {
+      case error instanceof RemoteSyncNetworkError:
+        this.handleNetworkError(error, syncItemType, itemName);
+        break;
+      case error instanceof RemoteSyncServerError:
+        this.handleServerError(error, syncItemType, itemName);
+        break;
+      case error instanceof RemoteSyncInvalidResponseError:
+        // no-op
+        break;
+      default:
+        this.handleRemoteSyncError(error, syncItemType, itemName);
+    }
+    this.reportErrorToSentry(error, syncItemType, itemCheckpoint);
+  }
+
+  handleSyncErrorWithIssue(
+    error: RemoteSyncError,
+    syncItemType: syncItemType,
+    errorDetail: {
+      errorLabel: string;
+      issue: VirtualDriveIssue;
+    }
+  ): void {
+    Logger.error(
+      `[SYNC MANAGER] Remote ${syncItemType} sync failed with ${errorDetail.errorLabel} error: `,
+      error
+    );
+    addVirtualDriveIssue(errorDetail.issue);
+  }
+
+  handleNetworkError(
+    error: RemoteSyncNetworkError,
+    syncItemType: syncItemType,
+    itemName: string
+  ): void {
+    const issues: VirtualDriveIssueByType = {
+      files: {
+        error: 'DOWNLOAD_ERROR', // Alternatively, use 'NETWORK_SYNC_ERROR'
+        cause: 'NO_REMOTE_CONNECTION', // Alternatively, use 'NETWORK_ERROR'
+        name: itemName,
+      },
+      folders: {
+        error: 'FOLDER_CREATE_ERROR', // Alternatively, use 'NETWORK_SYNC_ERROR'
+        cause: 'NO_REMOTE_CONNECTION', // Alternatively, use 'NETWORK_ERROR'
+        name: itemName,
+      },
+    };
+    this.handleSyncErrorWithIssue(error, syncItemType, {
+      errorLabel: 'network',
+      issue: issues[syncItemType],
+    });
+  }
+
+  handleServerError(
+    error: RemoteSyncServerError,
+    syncItemType: syncItemType,
+    itemName: string
+  ): void {
+    const issues: VirtualDriveIssueByType = {
+      files: {
+        error: 'DOWNLOAD_ERROR', // Alternatively, use 'SERVER_SYNC_ERROR'
+        cause: 'NO_REMOTE_CONNECTION', // Alternatively, use 'SERVER_ERROR'
+        name: itemName,
+      },
+      folders: {
+        error: 'FOLDER_CREATE_ERROR', // Alternatively, use 'SERVER_SYNC_ERROR'
+        cause: 'NO_REMOTE_CONNECTION', // Alternatively, use 'SERVER_ERROR'
+        name: itemName,
+      },
+    };
+    this.handleSyncErrorWithIssue(error, syncItemType, {
+      errorLabel: 'server',
+      issue: issues[syncItemType],
+    });
+  }
+
+  handleRemoteSyncError(
+    error: RemoteSyncError,
+    syncItemType: syncItemType,
+    itemName: string
+  ): void {
+    const issues: VirtualDriveIssueByType = {
+      files: {
+        error: 'DOWNLOAD_ERROR', // Alternatively, use 'REMOTE_SYNC_ERROR'
+        cause: 'NO_REMOTE_CONNECTION', // Alternatively, use 'REMOTE_SYNC_ERROR'
+        name: itemName,
+      },
+      folders: {
+        error: 'FOLDER_CREATE_ERROR', // Alternatively, use 'REMOTE_SYNC_ERROR'
+        cause: 'NO_REMOTE_CONNECTION', // Alternatively, use 'REMOTE_SYNC_ERROR'
+        name: itemName,
+      },
+    };
+
+    this.handleSyncErrorWithIssue(error, syncItemType, {
+      errorLabel: 'remote',
+      issue: issues[syncItemType],
+    });
+  }
+
+  reportErrorToSentry(
+    error: RemoteSyncError,
+    syncItemType: syncItemType,
+    itemCheckpoint?: Date
+  ): void {
+    switch (syncItemType) {
+      case 'files':
+        reportError(error, {
+          lastFilesSyncAt:
+            itemCheckpoint?.toISOString() ?? 'INITIAL_FILES_SYNC',
+        });
+        break;
+      case 'folders':
+        reportError(error, {
+          lastFoldersSyncAt:
+            itemCheckpoint?.toISOString() ?? 'INITIAL_FOLDERS_SYNC',
+        });
+        break;
+    }
+  }
+}

--- a/src/apps/main/remote-sync/RemoteSyncErrorHandler/RemoteSyncErrorHandler.ts
+++ b/src/apps/main/remote-sync/RemoteSyncErrorHandler/RemoteSyncErrorHandler.ts
@@ -61,13 +61,13 @@ export class RemoteSyncErrorHandler {
   ): void {
     const issues: VirtualDriveIssueByType = {
       files: {
-        error: 'DOWNLOAD_ERROR', // Alternatively, use 'NETWORK_SYNC_ERROR'
-        cause: 'NO_REMOTE_CONNECTION', // Alternatively, use 'NETWORK_ERROR'
+        error: 'DOWNLOAD_ERROR',
+        cause: 'NO_INTERNET',
         name: itemName,
       },
       folders: {
-        error: 'FOLDER_CREATE_ERROR', // Alternatively, use 'NETWORK_SYNC_ERROR'
-        cause: 'NO_REMOTE_CONNECTION', // Alternatively, use 'NETWORK_ERROR'
+        error: 'FOLDER_CREATE_ERROR',
+        cause: 'NO_INTERNET',
         name: itemName,
       },
     };
@@ -84,13 +84,13 @@ export class RemoteSyncErrorHandler {
   ): void {
     const issues: VirtualDriveIssueByType = {
       files: {
-        error: 'DOWNLOAD_ERROR', // Alternatively, use 'SERVER_SYNC_ERROR'
-        cause: 'NO_REMOTE_CONNECTION', // Alternatively, use 'SERVER_ERROR'
+        error: 'DOWNLOAD_ERROR',
+        cause: 'NO_REMOTE_CONNECTION',
         name: itemName,
       },
       folders: {
-        error: 'FOLDER_CREATE_ERROR', // Alternatively, use 'SERVER_SYNC_ERROR'
-        cause: 'NO_REMOTE_CONNECTION', // Alternatively, use 'SERVER_ERROR'
+        error: 'FOLDER_CREATE_ERROR',
+        cause: 'NO_REMOTE_CONNECTION',
         name: itemName,
       },
     };
@@ -107,13 +107,13 @@ export class RemoteSyncErrorHandler {
   ): void {
     const issues: VirtualDriveIssueByType = {
       files: {
-        error: 'DOWNLOAD_ERROR', // Alternatively, use 'REMOTE_SYNC_ERROR'
-        cause: 'NO_REMOTE_CONNECTION', // Alternatively, use 'REMOTE_SYNC_ERROR'
+        error: 'DOWNLOAD_ERROR',
+        cause: 'NO_REMOTE_CONNECTION',
         name: itemName,
       },
       folders: {
-        error: 'FOLDER_CREATE_ERROR', // Alternatively, use 'REMOTE_SYNC_ERROR'
-        cause: 'NO_REMOTE_CONNECTION', // Alternatively, use 'REMOTE_SYNC_ERROR'
+        error: 'FOLDER_CREATE_ERROR',
+        cause: 'NO_REMOTE_CONNECTION',
         name: itemName,
       },
     };

--- a/src/apps/main/remote-sync/errors.ts
+++ b/src/apps/main/remote-sync/errors.ts
@@ -1,0 +1,60 @@
+/**
+ * Base class for RemoteSync errors.
+ */
+export class RemoteSyncError extends Error {
+  public context?: any;
+  public code?: string;
+
+  constructor(message: string, code?: string, context?: any) {
+    super(message);
+    this.name = 'RemoteSyncError';
+    this.code = code;
+    this.context = context;
+  }
+}
+
+/**
+ * Error thrown when the response does not contain an array of files.
+ */
+export class RemoteSyncInvalidResponseError extends RemoteSyncError {
+  constructor(response: any) {
+    super(
+      `Expected an array of files, but received: ${JSON.stringify(
+        response,
+        null,
+        2
+      )}`,
+      'INVALID_RESPONSE',
+      { response }
+    );
+    this.name = 'RemoteSyncInvalidResponseError';
+  }
+}
+
+/**
+ * Error thrown when a network error occurs (example:, socket hang up or TLS connection error).
+ */
+export class RemoteSyncNetworkError extends RemoteSyncError {
+  constructor(originalError: any) {
+    super(
+      `Network error occurred during file sync: ${originalError.message}`,
+      'NETWORK_ERROR',
+      { originalError }
+    );
+    this.name = 'RemoteSyncNetworkError';
+  }
+}
+
+/**
+ * Error thrown when the server responds with an error status (example, status 500).
+ */
+export class RemoteSyncServerError extends RemoteSyncError {
+  constructor(status: number, data: any) {
+    super(
+      `Server error: request failed with status code ${status}`,
+      'SERVER_ERROR',
+      { status, data }
+    );
+    this.name = 'RemoteSyncServerError';
+  }
+}

--- a/src/apps/main/remote-sync/errors.ts
+++ b/src/apps/main/remote-sync/errors.ts
@@ -37,7 +37,7 @@ export class RemoteSyncInvalidResponseError extends RemoteSyncError {
 export class RemoteSyncNetworkError extends RemoteSyncError {
   constructor(originalError: any) {
     super(
-      `Network error occurred during file sync: ${originalError.message}`,
+      `Network error occurred during sync: ${originalError.message}`,
       'NETWORK_ERROR',
       { originalError }
     );
@@ -51,7 +51,7 @@ export class RemoteSyncNetworkError extends RemoteSyncError {
 export class RemoteSyncServerError extends RemoteSyncError {
   constructor(status: number, data: any) {
     super(
-      `Server error: request failed with status code ${status}`,
+      `Server error: request failed with status code ${status} while sync`,
       'SERVER_ERROR',
       { status, data }
     );

--- a/src/apps/main/remote-sync/service.ts
+++ b/src/apps/main/remote-sync/service.ts
@@ -7,11 +7,13 @@ import { RemoteSyncManager } from './RemoteSyncManager';
 import { reportError } from '../bug-report/service';
 import { broadcastToWindows } from '../windows';
 import { isInitialSyncReady, setInitialSyncState } from './InitialSyncReady';
+import { RemoteSyncErrorHandler } from './RemoteSyncErrorHandler/RemoteSyncErrorHandler';
 
 const SYNC_DEBOUNCE_DELAY = 3_000;
 
 const driveFilesCollection = new DriveFilesCollection();
 const driveFoldersCollection = new DriveFoldersCollection();
+const errorHandler = new RemoteSyncErrorHandler();
 
 export const remoteSyncManager = new RemoteSyncManager(
   {
@@ -24,7 +26,8 @@ export const remoteSyncManager = new RemoteSyncManager(
     fetchFoldersLimitPerRequest: 50,
     syncFiles: true,
     syncFolders: true,
-  }
+  },
+  errorHandler
 );
 
 remoteSyncManager.onStatusChange(async (newStatus) => {


### PR DESCRIPTION
## What is Changed / Added
I have added an error handler for the RemoteSyncManager  to properly propagate syncing errors though the app

----
## Why
Sometimes, network errors are just shown on the logs but not on the app, so the user does not really know what is going on and might be misleading