### PR TITLE
[PB-4038] Fix: upgrade inxt js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internxt",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "author": "Internxt <hello@internxt.com>",
   "description": "Internxt Drive client UI",
   "license": "AGPL-3.0",

--- a/package.json
+++ b/package.json
@@ -270,7 +270,7 @@
   "dependencies": {
     "@headlessui/react": "^1.4.2",
     "@iconscout/react-unicons": "^1.1.6",
-    "@internxt/inxt-js": "^2.0.8",
+    "@internxt/inxt-js": "^2.1.0",
     "@internxt/lib": "^1.1.6",
     "@internxt/sdk": "^1.5.24",
     "@phosphor-icons/react": "2.0.9",

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internxt",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Internxt Drive client UI",
   "main": "./dist/main/main.js",
   "author": "Internxt <hello@internxt.com>",

--- a/src/context/local/localFile/infrastructure/EnvironmentLocalFileUploader.ts
+++ b/src/context/local/localFile/infrastructure/EnvironmentLocalFileUploader.ts
@@ -12,7 +12,7 @@ import { DriveDesktopError } from '../../../shared/domain/errors/DriveDesktopErr
 
 @Service()
 export class EnvironmentLocalFileUploader implements LocalFileHandler {
-  private static MULTIPART_UPLOAD_SIZE_THRESHOLD = 5 * 1024 * 1024 * 1024;
+  private static MULTIPART_UPLOAD_SIZE_THRESHOLD = 100 * 1024 * 1024; // 100MB
 
   constructor(
     private readonly environment: Environment,

--- a/src/context/storage/TemporalFiles/infrastructure/downloader/TemporalFileDownloaderFactory.ts
+++ b/src/context/storage/TemporalFiles/infrastructure/downloader/TemporalFileDownloaderFactory.ts
@@ -17,7 +17,7 @@ export class TemporalFileDownloaderFactory
   private _replaces: Replaces | undefined = undefined;
   private _abortController: AbortController | undefined = undefined;
 
-  private static MULTIPART_UPLOAD_SIZE_THRESHOLD = 5 * 1024 * 1024 * 1024;
+  private static MULTIPART_UPLOAD_SIZE_THRESHOLD = 100 * 1024 * 1024; // 100MB
 
   constructor(
     private readonly environment: Environment,

--- a/src/context/storage/TemporalFiles/infrastructure/upload/EnvironmentTemporalFileUploaderFactory.ts
+++ b/src/context/storage/TemporalFiles/infrastructure/upload/EnvironmentTemporalFileUploaderFactory.ts
@@ -17,7 +17,7 @@ export class EnvironmentTemporalFileUploaderFactory
   private _replaces: Replaces | undefined = undefined;
   private _abortController: AbortController | undefined = undefined;
 
-  private static MULTIPART_UPLOAD_SIZE_THRESHOLD = 5 * 1024 * 1024 * 1024;
+  private static MULTIPART_UPLOAD_SIZE_THRESHOLD = 100 * 1024 * 1024; // 100MB
 
   constructor(
     private readonly environment: Environment,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1270,10 +1270,10 @@
     "@typescript-eslint/parser" "^5.4.0"
     eslint-config-prettier "^8.3.0"
 
-"@internxt/inxt-js@^2.0.8":
-  version "2.0.9"
-  resolved "https://npm.pkg.github.com/download/@internxt/inxt-js/2.0.9/063402c354b4c2d2052ae0cf1b38a37517abd833#063402c354b4c2d2052ae0cf1b38a37517abd833"
-  integrity sha512-ErH7L35JM8G0nOyEOKDRbF3NF4MsEhm/dbmUFkt4lfz1B3WIF+ocz92uCAdEej8Xdf/JAOsiclY9u94CLe1cHw==
+"@internxt/inxt-js@^2.1.0":
+  version "2.1.0"
+  resolved "https://npm.pkg.github.com/download/@internxt/inxt-js/2.1.0/cb76e567f3d2144d9877166572cdf614c4c69277#cb76e567f3d2144d9877166572cdf614c4c69277"
+  integrity sha512-Xx65Li3wRvXtDvXkTe44cM5l5DLMpvCkIFzNu0c78hi6xWlMXpl1JrMRiO0PHP+I3tOyRh/KAzUDQ92jRbzbBQ==
   dependencies:
     "@internxt/lib" "^1.1.6"
     "@internxt/sdk" "^1.4.27"


### PR DESCRIPTION
## What is Changed / Added
Upgraded the dependency @internxt/inxt-js to the latest version and lowered the minimum size file to where we start doing multipart upload from 5GB to 100MB
