### PR TITLE
Feat: Centralize the retrieval of user available Products

### DIFF
--- a/src/apps/main/config.ts
+++ b/src/apps/main/config.ts
@@ -2,6 +2,7 @@ import Store, { Schema } from 'electron-store';
 import * as uuid from 'uuid';
 
 import { User } from './types';
+import { AvailableProducts } from '@internxt/sdk/dist/drive/payments/types';
 
 // Fields to persist between user sessions
 export const fieldsToSave = [
@@ -42,6 +43,7 @@ export interface AppStore {
   virtualdriveWindowsLetter: string;
   nautilusExtensionVersion: number;
   discoveredBackup: number;
+  availableUserProducts?: AvailableProducts['featuresPerService'];
 }
 
 const schema: Schema<AppStore> = {
@@ -110,6 +112,7 @@ const schema: Schema<AppStore> = {
   },
   nautilusExtensionVersion: { type: 'number' },
   discoveredBackup: { type: 'number' },
+  availableUserProducts: { type: 'object' },
 } as const;
 
 export const defaults: AppStore = {
@@ -136,6 +139,7 @@ export const defaults: AppStore = {
   virtualdriveWindowsLetter: 'I',
   nautilusExtensionVersion: 0,
   discoveredBackup: 0,
+  availableUserProducts: undefined,
 };
 
 const configStore = new Store({ schema, defaults });

--- a/src/apps/main/event-bus.ts
+++ b/src/apps/main/event-bus.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 import { ProgressData } from './antivirus/ManualSystemScan';
+import { AvailableProducts } from '@internxt/sdk/dist/drive/payments/types';
 
 class EventBus extends EventEmitter {}
 
@@ -36,6 +37,10 @@ interface Events {
   ANTIVIRUS_SCAN_PROGRESS: (
     progress: ProgressData & { done?: boolean }
   ) => void;
+
+  GET_USER_AVAILABLE_PRODUCTS: () => void;
+
+  USER_AVAILABLE_PRODUCTS_UPDATED: (products: AvailableProducts['featuresPerService']) => void;
 }
 
 declare interface EventBus {

--- a/src/apps/main/main.ts
+++ b/src/apps/main/main.ts
@@ -31,6 +31,7 @@ import './config/handlers';
 import './app-info/handlers';
 import './remote-sync/handlers';
 import './virtual-drive';
+import './payments/handler';
 
 import { app, nativeTheme, ipcMain } from 'electron';
 import Logger from 'electron-log';
@@ -61,6 +62,7 @@ import { runFreshclam } from './antivirus/FreshclamUpdater';
 import dns from 'node:dns';
 import { clearDailyScan, scheduleDailyScan } from './antivirus/scanCronJob';
 import { setupAntivirusIpc } from './background-processes/antivirus/setupAntivirusIPC';
+import { registerAvailableUserProductsHandlers } from './payments/ipc/AvailableUserProductsIPCHandler';
 
 const gotTheLock = app.requestSingleInstanceLock();
 
@@ -138,6 +140,7 @@ app
     }
 
     checkForUpdates();
+    registerAvailableUserProductsHandlers();
   })
   .catch(Logger.error);
 

--- a/src/apps/main/payments/handler.ts
+++ b/src/apps/main/payments/handler.ts
@@ -1,0 +1,22 @@
+import eventBus from '../event-bus';
+import { buildPaymentsService } from './builder';
+import Logger from 'electron-log';
+
+async function getUserAvailableProductsAndStore() {
+  try {
+    const paymentsService = buildPaymentsService();
+    const products = await paymentsService.getAvailableProducts();
+    void paymentsService.storeUserProducts(products);
+    eventBus.emit('USER_AVAILABLE_PRODUCTS_UPDATED', products);
+  } catch (err) {
+    Logger.error(`[PRODUCTS] Failed to get user available products with error: ${err}`);
+  }
+}
+
+eventBus.on('USER_LOGGED_IN', () => {
+  void getUserAvailableProductsAndStore();
+});
+
+eventBus.on('GET_USER_AVAILABLE_PRODUCTS', () => {
+  void getUserAvailableProductsAndStore();
+});

--- a/src/apps/main/payments/ipc/AvailableUserProductsIPCHandler.ts
+++ b/src/apps/main/payments/ipc/AvailableUserProductsIPCHandler.ts
@@ -1,0 +1,22 @@
+import { AvailableUserProductsIPCMain } from './AvailableUserProductsIPCMain';
+import configStore from '../../config';
+import eventBus from '../../event-bus';
+
+/**
+ * Registers handlers for available user products IPC events.
+ */
+export function registerAvailableUserProductsHandlers() {
+  AvailableUserProductsIPCMain.handle('get-available-user-products', () => {
+    return configStore.get('availableUserProducts');
+  });
+
+
+  AvailableUserProductsIPCMain.on('subscribe-available-user-products', (event) => {
+    const currentUserProducts = configStore.get('availableUserProducts');
+    event.sender.send('available-user-products-updated', currentUserProducts);
+
+    eventBus.on('USER_AVAILABLE_PRODUCTS_UPDATED', (products) => {
+      event.sender.send('available-user-products-updated', products);
+    });
+  });
+}

--- a/src/apps/main/payments/ipc/AvailableUserProductsIPCHandler.ts
+++ b/src/apps/main/payments/ipc/AvailableUserProductsIPCHandler.ts
@@ -1,22 +1,37 @@
 import { AvailableUserProductsIPCMain } from './AvailableUserProductsIPCMain';
 import configStore from '../../config';
 import eventBus from '../../event-bus';
+import logger from '../../logger';
 
 /**
  * Registers handlers for available user products IPC events.
  */
 export function registerAvailableUserProductsHandlers() {
   AvailableUserProductsIPCMain.handle('get-available-user-products', () => {
-    return configStore.get('availableUserProducts');
+    try {
+      logger.info('[IPC] Received get-available-user-products request');
+      return configStore.get('availableUserProducts');
+    } catch (error) {
+      logger.error('[IPC] Error in get-available-user-products handler:', error);
+      throw error;
+    }
   });
 
 
   AvailableUserProductsIPCMain.on('subscribe-available-user-products', (event) => {
-    const currentUserProducts = configStore.get('availableUserProducts');
-    event.sender.send('available-user-products-updated', currentUserProducts);
+    try {
+      logger.info('[IPC] Received subscribe-available-user-products request');
+      const currentUserProducts = configStore.get('availableUserProducts');
+      event.sender.send('available-user-products-updated', currentUserProducts);
 
-    eventBus.on('USER_AVAILABLE_PRODUCTS_UPDATED', (products) => {
-      event.sender.send('available-user-products-updated', products);
-    });
+
+      eventBus.on('USER_AVAILABLE_PRODUCTS_UPDATED', (products) => {
+        logger.info('[IPC] Received USER_AVAILABLE_PRODUCTS_UPDATED event');
+        event.sender.send('available-user-products-updated', products);
+      });
+    } catch (error) {
+      logger.error('[IPC] Error in subscribe-available-user-products handler:', error);
+      throw error;
+    }
   });
 }

--- a/src/apps/main/payments/ipc/AvailableUserProductsIPCMain.ts
+++ b/src/apps/main/payments/ipc/AvailableUserProductsIPCMain.ts
@@ -1,0 +1,13 @@
+import { ipcMain } from 'electron';
+import { TypedIPC } from '../../../shared/IPC/TypedIPC';
+import { MainProcessAvailableUserProductsMessages } from './messages/MainProcessAvailableUserProductsMessages';
+import { RendererProcessAvailableUserProductsMessages } from './messages/RendererProcessAvailableUserProductsMessages';
+
+/**
+ * Typed IPC for the user's products availability communication in the main process
+ */
+export type AvailableUserProductsIPCMain = TypedIPC<
+  RendererProcessAvailableUserProductsMessages,
+  MainProcessAvailableUserProductsMessages
+>;
+export const AvailableUserProductsIPCMain = ipcMain as unknown as AvailableUserProductsIPCMain;

--- a/src/apps/main/payments/ipc/AvailableUserProductsIPCRenderer.ts
+++ b/src/apps/main/payments/ipc/AvailableUserProductsIPCRenderer.ts
@@ -1,0 +1,16 @@
+import { ipcRenderer } from 'electron';
+import { TypedIPC } from '../../../shared/IPC/TypedIPC';
+import { MainProcessAvailableUserProductsMessages } from './messages/MainProcessAvailableUserProductsMessages';
+import { RendererProcessAvailableUserProductsMessages } from './messages/RendererProcessAvailableUserProductsMessages';
+
+/**
+ * Typed IPC for the user's products availability communication in the renderer process
+ */
+export type AvailableUserProductsIPCRenderer = TypedIPC<
+  MainProcessAvailableUserProductsMessages,
+  RendererProcessAvailableUserProductsMessages
+>;
+
+
+export const AvailableUserProductsIPCRenderer = ipcRenderer as unknown as AvailableUserProductsIPCRenderer;
+

--- a/src/apps/main/payments/ipc/messages/MainProcessAvailableUserProductsMessages.ts
+++ b/src/apps/main/payments/ipc/messages/MainProcessAvailableUserProductsMessages.ts
@@ -1,0 +1,20 @@
+/**
+ * Messages that can be sent from the main process to the renderer process
+ * related to the user's available products
+ */
+import { AvailableProducts } from '@internxt/sdk/dist/drive/payments/types';
+
+export type MainProcessAvailableUserProductsMessages = {
+  /**
+   * Get the available products for the current user
+   * @returns AvailableProducts['featuresPerService'] The available products
+   *  or undefined if there are no available products object
+   */
+  'get-available-user-products': () => AvailableProducts['featuresPerService'] | undefined;
+
+  /**
+   * Subscribe to available user products changes
+   * @returns void
+   */
+  'subscribe-available-user-products': () => void;
+}

--- a/src/apps/main/payments/ipc/messages/RendererProcessAvailableUserProductsMessages.ts
+++ b/src/apps/main/payments/ipc/messages/RendererProcessAvailableUserProductsMessages.ts
@@ -1,0 +1,9 @@
+import { AvailableProducts } from '@internxt/sdk/dist/drive/payments/types';
+
+export type RendererProcessAvailableUserProductsMessages = {
+  /**
+   * gets the updated available user products
+   * @param products
+   */
+  'available-user-products-updated': (products: AvailableProducts['featuresPerService']) => void
+}

--- a/src/apps/main/payments/service.ts
+++ b/src/apps/main/payments/service.ts
@@ -1,5 +1,6 @@
 import { Payments } from '@internxt/sdk/dist/drive';
 import { AvailableProducts } from '@internxt/sdk/dist/drive/payments/types';
+import configStore from '../config';
 
 export class PaymentsService {
   constructor(private readonly payments: Payments) {}
@@ -8,5 +9,9 @@ export class PaymentsService {
     const products = await this.payments.checkUserAvailableProducts();
 
     return products.featuresPerService;
+  }
+
+  async storeUserProducts(products: AvailableProducts['featuresPerService']): Promise<void> {
+    configStore.set('availableUserProducts', products);
   }
 }

--- a/src/apps/main/preload.d.ts
+++ b/src/apps/main/preload.d.ts
@@ -1,3 +1,5 @@
+import { AvailableProducts } from '@internxt/sdk/dist/drive/payments/types';
+
 declare interface Window {
   electron: {
     getConfigKey(key: import('./config/service').StoredValues): Promise<any>;
@@ -269,5 +271,13 @@ declare interface Window {
       removeInfectedFiles: (infectedFiles: string[]) => Promise<void>;
       cancelScan: () => Promise<void>;
     };
+
+    userAvailableProducts: {
+      get: () => AvailableProducts['featuresPerService'] | undefined;
+      subscribe: () => void;
+      onUpdated: (
+        callback: (products: AvailableProducts['featuresPerService']) => void
+      ) => void;
+    }
   };
 }

--- a/src/apps/main/preload.js
+++ b/src/apps/main/preload.js
@@ -1,5 +1,6 @@
 const { contextBridge, ipcRenderer } = require('electron');
 const path = require('path');
+const { AvailableProducts } = require('@internxt/sdk/dist/drive/payments/types');
 
 contextBridge.exposeInMainWorld('electron', {
   getConfigKey(key) {
@@ -406,5 +407,18 @@ contextBridge.exposeInMainWorld('electron', {
     cancelScan: () => {
       return ipcRenderer.invoke('antivirus:cancel-scan');
     },
+  },
+  userAvailableProducts: {
+    get: () => ipcRenderer.invoke('get-available-user-products'),
+    subscribe: () => ipcRenderer.send('subscribe-available-user-products'),
+    onUpdate: (callback) => {
+      const listener = (_event, products) => {
+        callback(products);
+      };
+      ipcRenderer.on('available-user-products-updated', listener);
+      return () => {
+        ipcRenderer.removeListener('available-user-products-updated', listener);
+      };
+    }
   },
 });

--- a/src/apps/main/realtime.ts
+++ b/src/apps/main/realtime.ts
@@ -87,6 +87,8 @@ function cleanAndStartRemoteNotifications() {
       eventPayload.bucket = data.payload.bucket;
     }
 
+    eventBus.emit('GET_USER_AVAILABLE_PRODUCTS');
+
     broadcastToWindows('remote-changes', eventPayload);
 
 

--- a/src/apps/renderer/hooks/useUserAvailableProducts/useUserAvailableProducts.ts
+++ b/src/apps/renderer/hooks/useUserAvailableProducts/useUserAvailableProducts.ts
@@ -1,0 +1,25 @@
+import { AvailableProducts } from '@internxt/sdk/dist/drive/payments/types';
+import { useEffect, useState } from 'react';
+
+export function useUserAvailableProducts() {
+  const [products, setProducts] = useState<AvailableProducts['featuresPerService'] | undefined>(undefined);
+
+  const handleSetProducts = (products: AvailableProducts['featuresPerService'] | undefined) => {
+    setProducts(products);
+  };
+
+  useEffect(() => {
+    const { userAvailableProducts } = window.electron;
+    userAvailableProducts.get().then(handleSetProducts);
+
+    userAvailableProducts.subscribe();
+
+    const listener = userAvailableProducts.onUpdate(handleSetProducts);
+
+    return listener;
+  }, []);
+
+  return {
+    products,
+  };
+}

--- a/src/apps/renderer/pages/Settings/Backups/index.tsx
+++ b/src/apps/renderer/pages/Settings/Backups/index.tsx
@@ -18,7 +18,6 @@ export default function BackupsSection({
   showIssues,
 }: BackupsSectionProps) {
   const { deviceState } = useContext(DeviceContext);
-  const { products } = useUserAvailableProducts(); // Placeholder for the useUserAvailableProducts hook
   return (
     <div className={`${active ? 'block' : 'hidden'} w-full`}>
       {deviceState.status === 'LOADING' && (

--- a/src/apps/renderer/pages/Settings/Backups/index.tsx
+++ b/src/apps/renderer/pages/Settings/Backups/index.tsx
@@ -4,6 +4,7 @@ import { DeviceSettings } from './DeviceSettings';
 import { DevicesList } from './DevicesList';
 import { ScrollableContent } from '../../../components/ScrollableContent';
 import Spinner from '../../../assets/spinner.svg';
+import { useUserAvailableProducts } from '../../../hooks/useUserAvailableProducts/useUserAvailableProducts';
 
 interface BackupsSectionProps {
   active: boolean;
@@ -17,7 +18,7 @@ export default function BackupsSection({
   showIssues,
 }: BackupsSectionProps) {
   const { deviceState } = useContext(DeviceContext);
-
+  const { products } = useUserAvailableProducts(); // Placeholder for the useUserAvailableProducts hook
   return (
     <div className={`${active ? 'block' : 'hidden'} w-full`}>
       {deviceState.status === 'LOADING' && (


### PR DESCRIPTION
## What is Changed / Added
### Centralized the retrieval of the user available products

Every time that we recieve a notification on remote-changes, we emit an event called **GET_USER_AVAILABLE_PRODUCTS** so that a handler can request for the latest user products.

With the latest products, we can store them on the configStore so that we have persistance on the data.
Also, on the frontend, we created a custom hook so that we can always have this data available alongside the real time changes on said data.

----
## Why

This way, we can have an easy to use hook in the frontend for consuming this data and its real time changes, and we also have a centralized, single source of truth way to store/retrieve/request the data
