### PR TITLE
Chore/migrate login and access url to new api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ src/test/screenshots
 *.db
 
 clamAV/**
+
+# Http Client
+/http/*.env.json

--- a/http/auth/login.http
+++ b/http/auth/login.http
@@ -1,0 +1,11 @@
+// @no-log
+### POST request to /login
+POST {{NEW_DRIVE_URL}}/auth/login
+Content-Type: application/json
+internxt-client: drive-desktop
+internxt-version: '2.4.8'
+x-internxt-desktop-header: {{INTERNXT_DESKTOP_HEADER_KEY}}
+
+{
+  "email": "{{USER_EMAIL}}"
+}

--- a/http/http-client.env.example.json
+++ b/http/http-client.env.example.json
@@ -1,0 +1,8 @@
+{
+  "prod": {
+    "API_URL": "",
+    "NEW_DRIVE_URL": "",
+    "INTERNXT_DESKTOP_HEADER_KEY": "",
+    "USER_EMAIL": ""
+  }
+}

--- a/src/apps/main/auth/service.ts
+++ b/src/apps/main/auth/service.ts
@@ -115,15 +115,22 @@ export function getHeaders(includeMnemonic = false): Record<string, string> {
   return header;
 }
 
+export function getBaseApiHeaders():  Record<string, string> {
+  return {
+    'content-type': 'application/json; charset=utf-8',
+    'internxt-client': 'drive-desktop',
+    'internxt-version': packageConfig.version,
+    'x-internxt-desktop-header': process.env.INTERNXT_DESKTOP_HEADER_KEY || '',
+  };
+}
+
+
 export function getNewApiHeaders(): Record<string, string> {
   const token = obtainToken('newToken');
 
   return {
     Authorization: `Bearer ${token}`,
-    'content-type': 'application/json; charset=utf-8',
-    'internxt-client': 'drive-desktop',
-    'internxt-version': packageConfig.version,
-    'x-internxt-desktop-header': process.env.INTERNXT_DESKTOP_HEADER_KEY || '',
+    ...getBaseApiHeaders(),
   };
 }
 

--- a/src/apps/main/interface.d.ts
+++ b/src/apps/main/interface.d.ts
@@ -1,6 +1,10 @@
 import { AvailableProducts } from '@internxt/sdk/dist/drive/payments/types';
 import { Device } from './device/service';
-import { AuthLoginResponseViewModel } from '../../infra/drive-server/services/auth/auth.types';
+import {
+  AuthAccessResponseViewModel,
+  AuthLoginResponseViewModel,
+  LoginAccessRequest
+} from '../../infra/drive-server/services/auth/auth.types';
 /** This interface and declare global will replace the preload.d.ts.
 * The thing is that instead of that, we will gradually will be declaring the interface here as we generate tests
 * And we need to mock the electron API.
@@ -31,7 +35,8 @@ export interface IElectronAPI {
       callback: (products: AvailableProducts['featuresPerService']) => void
     ) => void;
   };
-  login(email: string): Promise<AuthLoginResponseViewModel>
+  login(email: string): Promise<AuthLoginResponseViewModel>;
+  access(credentials: LoginAccessRequest): Promise<AuthAccessResponseViewModel>;
 }
 
 declare global {

--- a/src/apps/main/interface.d.ts
+++ b/src/apps/main/interface.d.ts
@@ -1,5 +1,6 @@
 import { AvailableProducts } from '@internxt/sdk/dist/drive/payments/types';
 import { Device } from './device/service';
+import { AuthLoginResponseViewModel } from '../../infra/drive-server/services/auth/auth.types';
 /** This interface and declare global will replace the preload.d.ts.
 * The thing is that instead of that, we will gradually will be declaring the interface here as we generate tests
 * And we need to mock the electron API.
@@ -30,6 +31,7 @@ export interface IElectronAPI {
       callback: (products: AvailableProducts['featuresPerService']) => void
     ) => void;
   };
+  login(email: string): Promise<AuthLoginResponseViewModel>
 }
 
 declare global {

--- a/src/apps/main/main.ts
+++ b/src/apps/main/main.ts
@@ -61,12 +61,14 @@ import dns from 'node:dns';
 import { setupAntivirusIpc } from './background-processes/antivirus/setupAntivirusIPC';
 import { registerAvailableUserProductsHandlers } from './payments/ipc/AvailableUserProductsIPCHandler';
 import { getAntivirusManager } from './antivirus/antivirusManager';
+import { registerAuthIPCHandlers } from '../../infra/ipc/auth-ipc-handlers';
 
 const gotTheLock = app.requestSingleInstanceLock();
 
 if (!gotTheLock) {
   app.quit();
 }
+registerAuthIPCHandlers();
 
 Logger.log(`Running ${packageJson.version}`);
 

--- a/src/apps/main/preload.d.ts
+++ b/src/apps/main/preload.d.ts
@@ -1,4 +1,5 @@
 import { AvailableProducts } from '@internxt/sdk/dist/drive/payments/types';
+import { AuthLoginResponseViewModel } from '../../infra/drive-server/services/auth/auth.types';
 
 declare interface Window {
   electron: {
@@ -279,5 +280,7 @@ declare interface Window {
         callback: (products: AvailableProducts['featuresPerService']) => void
       ) => void;
     }
+
+    login(email: string): Promise<AuthLoginResponseViewModel>
   };
 }

--- a/src/apps/main/preload.js
+++ b/src/apps/main/preload.js
@@ -420,4 +420,5 @@ contextBridge.exposeInMainWorld('electron', {
       };
     }
   },
+  login: (email) => ipcRenderer.invoke('auth:login', email),
 });

--- a/src/apps/main/preload.js
+++ b/src/apps/main/preload.js
@@ -421,4 +421,5 @@ contextBridge.exposeInMainWorld('electron', {
     }
   },
   login: (email) => ipcRenderer.invoke('auth:login', email),
+  access: (credentials) => ipcRenderer.invoke('auth:access', credentials),
 });

--- a/src/apps/renderer/pages/Login/index.tsx
+++ b/src/apps/renderer/pages/Login/index.tsx
@@ -10,7 +10,6 @@ import Button from '../../components/Button';
 import PasswordInput from '../../components/PasswordInput';
 import TextInput from '../../components/TextInput';
 import WindowTopBar from '../../components/WindowTopBar';
-import { driveServerModule } from '../../../../infra/drive-server/drive-server.module';
 
 const TOWFA_ERROR_MESSAGE = 'Wrong 2-factor auth code';
 
@@ -72,9 +71,9 @@ export default function Login() {
     }
 
     try {
-      const response = await driveServerModule.auth.login(email);
-      if (response.isRight()) {
-        const body = response.getRight();
+      const response = await window.electron.login(email);
+      if (response.success) {
+        const body = response.data;
         sKey.current = body.sKey;
         if (body.tfa) {
           setState('ready');
@@ -82,10 +81,9 @@ export default function Login() {
         } else {
           access();
         }
-      }
-      if (response.isLeft()) {
+      } else {
         setState('error');
-        setErrorDetails(response.getLeft().message);
+        setErrorDetails(response.error);
       }
     } catch (err) {
       setState('error');

--- a/src/apps/renderer/pages/Login/service.ts
+++ b/src/apps/renderer/pages/Login/service.ts
@@ -75,36 +75,3 @@ export async function accessRequest(
 
   return res;
 }
-
-export async function loginRequest(email: string): Promise<{
-  sKey: string;
-  tfa: boolean;
-}> {
-  const fallbackErrorMessage = 'Error while logging in';
-
-  let loginRes;
-
-  try {
-    loginRes = await fetch(`${process.env.API_URL}/login`, {
-      method: 'POST',
-      body: JSON.stringify({ email }),
-      headers: {
-        'content-type': 'application/json',
-        'internxt-client': 'drive-desktop',
-        'internxt-version': packageConfig.version,
-        'x-internxt-desktop-header': process.env.INTERNXT_DESKTOP_HEADER_KEY || '',
-      },
-    });
-  } catch {
-    throw new Error(fallbackErrorMessage);
-  }
-
-  const body = await loginRes.json();
-
-  if (!loginRes.ok) {
-    const errorMessage = body.error ?? 'Error while logging in';
-    throw new Error(errorMessage);
-  }
-
-  return body;
-}

--- a/src/apps/renderer/pages/Login/service.ts
+++ b/src/apps/renderer/pages/Login/service.ts
@@ -1,6 +1,4 @@
 import CryptoJS from 'crypto-js';
-
-import packageConfig from '../../../../../package.json';
 import { User } from '../../../main/types';
 
 export function hashPassword(password: string, sKey: string): string {
@@ -41,37 +39,16 @@ export async function accessRequest(
 ): Promise<AccessResponse> {
   const fallbackErrorMessage = 'Error while logging in';
 
-  let accessRes;
-  try {
-    accessRes = await fetch(`${process.env.API_URL}/access`, {
-      method: 'POST',
-      body: JSON.stringify({
-        email: email.toLowerCase(),
-        password: hashedPassword,
-        tfa,
-      }),
-      headers: {
-        'content-type': 'application/json',
-        'internxt-client': 'drive-desktop',
-        'internxt-version': packageConfig.version,
-        'x-internxt-desktop-header': process.env.INTERNXT_DESKTOP_HEADER_KEY || '',
-      },
-    });
-  } catch {
-    throw new Error(fallbackErrorMessage);
-  }
-  if (!accessRes.ok) {
-    const body = await accessRes.json();
-    const errorMessage = body.error ?? fallbackErrorMessage;
+  const response = await window.electron.access({ email, password: hashedPassword, tfa });
+  if (!response.success) {
+    const errorMessage = response.error ?? fallbackErrorMessage;
     throw new Error(errorMessage);
+  } else {
+    const { data } = response;
+    data.user.mnemonic = CryptoJS.AES.decrypt(
+      CryptoJS.enc.Hex.parse(data.user.mnemonic).toString(CryptoJS.enc.Base64),
+      password
+    ).toString(CryptoJS.enc.Utf8);
+    return data;
   }
-
-  const res: AccessResponse = await accessRes.json();
-
-  res.user.mnemonic = CryptoJS.AES.decrypt(
-    CryptoJS.enc.Hex.parse(res.user.mnemonic).toString(CryptoJS.enc.Base64),
-    password
-  ).toString(CryptoJS.enc.Utf8);
-
-  return res;
 }

--- a/src/infra/drive-server/drive-server.client.ts
+++ b/src/infra/drive-server/drive-server.client.ts
@@ -1,0 +1,120 @@
+import axios from 'axios';
+
+type HTTPMethod = 'get' | 'post' | 'put' | 'delete' | 'patch';
+
+/*
+ * Utility types — these extract request/response typings out of the generated
+ * `paths` object. They mirror the helpers used by openapi‑fetch.
+ * */
+
+/**
+ * Extracts the shape (request + responses) of a particular method `M` from
+ * an endpoint schema `T` (i.e. one value of the `paths` record).
+ */
+type MethodShape<T, M extends HTTPMethod> = T extends Record<M, infer R>
+  ? R
+  : never;
+
+/**
+ * Produces a union of endpoint paths (string literals) that implement the
+ * HTTP method `M`.
+ *
+ * Example: `PathsWithMethod<paths, 'post'>` might yield
+ * `'/auth/login' | '/users/refresh' | '/auth/login/access'`.
+ */
+type PathsWithMethod<T, M extends HTTPMethod> = {
+  [P in keyof T]: MethodShape<T[P], M> extends never ? never : P;
+}[keyof T] &
+  string;
+
+/**
+ * Infers the JSON request body for an endpoint. If the operation does not
+ * define a request body the result is `never` (body becomes optional).
+ */
+type OperationRequestBody<
+  T,
+  P extends keyof T,
+  M extends HTTPMethod
+> = MethodShape<T[P], M> extends {
+  requestBody?: { content: { 'application/json': infer Req } };
+}
+  ? Req
+  : never;
+
+/**
+ * Infers the JSON response payload for status 200 or 201.
+ * Extend here if your API uses 202/204 etc. for success responses.
+ */
+type OperationResponse<
+  T,
+  P extends keyof T,
+  M extends HTTPMethod
+> = MethodShape<T[P], M> extends {
+  responses: {
+    200?: { content: { 'application/json': infer Res } };
+    201?: { content: { 'application/json': infer Res } };
+  };
+}
+  ? Res
+  : never;
+
+/**
+ * Creates a client bound to a specific OpenAPI `paths` record.
+ *
+ * @template T The generated `paths` type (from openapi‑typescript).
+ * @param baseUrl The base URL of the API (e.g. 'https://api.internxt.com/drive').
+ * @returns an object with GET/POST/… methods, each one fully typed.
+ */
+export function createClient<T>(opts: { baseUrl: string }) {
+  // Strip trailing slash to avoid double // when concatenating.
+  const http = axios.create({
+    baseURL: opts.baseUrl.replace(/\/$/, ''),
+    timeout: 15_000,
+    headers: { 'content-type': 'application/json' },
+  });
+
+  /**
+   * Low‑level helper that performs the actual Axios call.
+   * It preserves full typing between request and response.
+   */
+  async function request<M extends HTTPMethod, P extends PathsWithMethod<T, M>>(
+    method: M,
+    path: P,
+    o?: {
+      headers?: Record<string, string>;
+      query?: Record<string, any>;
+      body?: OperationRequestBody<T, P, M>;
+    }
+  ): Promise<{ data: OperationResponse<T, P, M> }> {
+    try {
+      const { data } = await http.request({
+        method,
+        url: path,
+        headers: o?.headers,
+        params: o?.query,
+        data: o?.body,
+      });
+      return { data };
+    } catch (err) {
+      // If the server responded with 4xx/5xx we still return the body so callers
+      // can decide what to do. Network errors are re‑thrown.
+      if (axios.isAxiosError(err) && err.response) {
+        return { data: err.response.data as OperationResponse<T, P, M> };
+      }
+      throw err;
+    }
+  }
+
+  return {
+    GET: <P extends PathsWithMethod<T, 'get'>>(p: P, o?: any) =>
+      request('get', p, o),
+    POST: <P extends PathsWithMethod<T, 'post'>>(p: P, o?: any) =>
+      request('post', p, o),
+    PUT: <P extends PathsWithMethod<T, 'put'>>(p: P, o?: any) =>
+      request('put', p, o),
+    PATCH: <P extends PathsWithMethod<T, 'patch'>>(p: P, o?: any) =>
+      request('patch', p, o),
+    DELETE: <P extends PathsWithMethod<T, 'delete'>>(p: P, o?: any) =>
+      request('delete', p, o),
+  };
+}

--- a/src/infra/drive-server/services/auth/auth.client.ts
+++ b/src/infra/drive-server/services/auth/auth.client.ts
@@ -1,8 +1,6 @@
-import createClient, { ClientOptions } from 'openapi-fetch';
 import { paths } from '../../../schemas';
+import { createClient } from '../../drive-server.client';
 
-const clientOptions: ClientOptions = {
-  baseUrl: process.env.NEW_DRIVE_URL
-};
-
-export const authClient = createClient<paths>(clientOptions);
+export const authClient = createClient<paths>({
+  baseUrl: process.env.NEW_DRIVE_URL || '',
+});

--- a/src/infra/drive-server/services/auth/auth.service.ts
+++ b/src/infra/drive-server/services/auth/auth.service.ts
@@ -5,8 +5,7 @@ import { Either, left, right } from '../../../../context/shared/domain/Either';
 import { RefreshTokenResponse } from './auth.types';
 
 export class AuthService {
-  constructor() {
-  }
+  constructor() {}
 
   async refresh(): Promise<Either<Error, RefreshTokenResponse>> {
     try {

--- a/src/infra/drive-server/services/auth/auth.service.ts
+++ b/src/infra/drive-server/services/auth/auth.service.ts
@@ -1,11 +1,39 @@
 import { authClient } from './auth.client';
-import { getNewApiHeaders } from '../../../../apps/main/auth/service';
+import { getBaseApiHeaders, getNewApiHeaders } from '../../../../apps/main/auth/service';
 import { logger } from '../../../../core/LoggerService/LoggerService';
 import { Either, left, right } from '../../../../context/shared/domain/Either';
-import { RefreshTokenResponse } from './auth.types';
+import { LoginResponse, RefreshTokenResponse } from './auth.types';
 
 export class AuthService {
-  constructor() {
+
+  async login(email: string): Promise<Either<Error, LoginResponse>> {
+    try {
+      const response = await authClient.POST('/auth/login', {
+        body: { email },
+        headers: getBaseApiHeaders(),
+      });
+
+      if (!response.data) {
+        logger.error({
+          msg: 'Login request was not successful',
+          tag: 'AUTH',
+          attributes: { endpoint: '/auth/login' },
+        });
+        return left(new Error('Login request was not successful'));
+      }
+      return right(response.data);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      logger.error({
+        msg: 'Login request threw an exception',
+        tag: 'AUTH',
+        error: error,
+        attributes: {
+          endpoint: '/auth/login',
+        },
+      });
+      return left(error);
+    }
   }
 
   async refresh(): Promise<Either<Error, RefreshTokenResponse>> {

--- a/src/infra/drive-server/services/auth/auth.service.ts
+++ b/src/infra/drive-server/services/auth/auth.service.ts
@@ -5,7 +5,8 @@ import { Either, left, right } from '../../../../context/shared/domain/Either';
 import { RefreshTokenResponse } from './auth.types';
 
 export class AuthService {
-  constructor() {}
+  constructor() {
+  }
 
   async refresh(): Promise<Either<Error, RefreshTokenResponse>> {
     try {

--- a/src/infra/drive-server/services/auth/auth.service.ts
+++ b/src/infra/drive-server/services/auth/auth.service.ts
@@ -1,10 +1,50 @@
 import { authClient } from './auth.client';
-import { getBaseApiHeaders, getNewApiHeaders } from '../../../../apps/main/auth/service';
+import {
+  getBaseApiHeaders,
+  getNewApiHeaders,
+} from '../../../../apps/main/auth/service';
 import { logger } from '../../../../core/LoggerService/LoggerService';
 import { Either, left, right } from '../../../../context/shared/domain/Either';
-import { LoginResponse, RefreshTokenResponse } from './auth.types';
+import {
+  LoginAccessRequest,
+  LoginAccessResponse,
+  LoginResponse,
+  RefreshTokenResponse,
+} from './auth.types';
 
 export class AuthService {
+  async access(
+    credentials: LoginAccessRequest
+  ): Promise<Either<Error, LoginAccessResponse>> {
+    const { email, password, tfa } = credentials;
+    try {
+      const response = await authClient.POST('/auth/login/access', {
+        body: { email, password, tfa },
+        headers: getBaseApiHeaders(),
+      });
+
+      if (!response.data) {
+        logger.error({
+          msg: 'Access request was not successful',
+          tag: 'AUTH',
+          attributes: { endpoint: '/auth/login/access' },
+        });
+        return left(new Error('Access request was not successful'));
+      }
+      return right(response.data);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      logger.error({
+        msg: 'Access request threw an exception',
+        tag: 'AUTH',
+        error: error,
+        attributes: {
+          endpoint: '/auth/login/access',
+        },
+      });
+      return left(error);
+    }
+  }
 
   async login(email: string): Promise<Either<Error, LoginResponse>> {
     try {
@@ -39,7 +79,7 @@ export class AuthService {
   async refresh(): Promise<Either<Error, RefreshTokenResponse>> {
     try {
       const response = await authClient.GET('/users/refresh', {
-        headers: await getNewApiHeaders()
+        headers: await getNewApiHeaders(),
       });
 
       if (!response.data) {
@@ -47,8 +87,8 @@ export class AuthService {
           msg: 'Refresh request was not successful',
           tag: 'AUTH',
           attributes: {
-            endpoint: '/users/refresh'
-          }
+            endpoint: '/users/refresh',
+          },
         });
         return left(new Error('Refresh request was not successful'));
       }
@@ -60,8 +100,8 @@ export class AuthService {
         tag: 'AUTH',
         error: error,
         attributes: {
-          endpoint: '/auth/login'
-        }
+          endpoint: '/auth/login',
+        },
       });
       return left(error);
     }

--- a/src/infra/drive-server/services/auth/auth.types.ts
+++ b/src/infra/drive-server/services/auth/auth.types.ts
@@ -10,3 +10,7 @@ export interface LoginResponse {
   hasKyberKeys: boolean;
   hasEccKeys: boolean;
 }
+
+export type AuthLoginResponseViewModel =
+  | { success: true; data: LoginResponse }
+  | { success: false; error: string };

--- a/src/infra/drive-server/services/auth/auth.types.ts
+++ b/src/infra/drive-server/services/auth/auth.types.ts
@@ -2,3 +2,11 @@ export interface RefreshTokenResponse {
   token: string;
   newToken: string;
 }
+
+export interface LoginResponse {
+  hasKeys: boolean;
+  sKey: string;
+  tfa: boolean;
+  hasKyberKeys: boolean;
+  hasEccKeys: boolean;
+}

--- a/src/infra/drive-server/services/auth/auth.types.ts
+++ b/src/infra/drive-server/services/auth/auth.types.ts
@@ -1,3 +1,5 @@
+import { components } from 'src/infra/schemas';
+
 export interface RefreshTokenResponse {
   token: string;
   newToken: string;
@@ -13,4 +15,21 @@ export interface LoginResponse {
 
 export type AuthLoginResponseViewModel =
   | { success: true; data: LoginResponse }
+  | { success: false; error: string };
+
+export interface LoginAccessRequest {
+  email: string;
+  password: string;
+  tfa?: string;
+}
+
+export interface LoginAccessResponse {
+  user: components['schemas']['UserDto'];
+  token: string;
+  userTeam: Record<string, never>;
+  newToken: string;
+}
+
+export type AuthAccessResponseViewModel =
+  | { success: true; data: LoginAccessResponse }
   | { success: false; error: string };

--- a/src/infra/ipc/auth-emitted-events.ts
+++ b/src/infra/ipc/auth-emitted-events.ts
@@ -1,7 +1,11 @@
 import { driveServerModule } from '../drive-server/drive-server.module';
-
+import { LoginAccessRequest } from '../drive-server/services/auth/auth.types';
 export type EmittedEvents = {
   'auth:login': (
-    props: Parameters<(typeof driveServerModule)['auth']['login']>[0],
+    props: Parameters<(typeof driveServerModule)['auth']['login']>[0]
   ) => ReturnType<(typeof driveServerModule)['auth']['login']>;
+
+  'auth:access': (
+    props: LoginAccessRequest
+  ) => ReturnType<(typeof driveServerModule)['auth']['access']>;
 };

--- a/src/infra/ipc/auth-emitted-events.ts
+++ b/src/infra/ipc/auth-emitted-events.ts
@@ -1,0 +1,7 @@
+import { driveServerModule } from '../drive-server/drive-server.module';
+
+export type EmittedEvents = {
+  'auth:login': (
+    props: Parameters<(typeof driveServerModule)['auth']['login']>[0],
+  ) => ReturnType<(typeof driveServerModule)['auth']['login']>;
+};

--- a/src/infra/ipc/auth-ipc-handlers.ts
+++ b/src/infra/ipc/auth-ipc-handlers.ts
@@ -1,0 +1,17 @@
+import { IpcMainInvokeEvent } from 'electron';
+import { driveServerModule } from '../drive-server/drive-server.module';
+import { AuthIPCMain } from './auth-ipc-main';
+import { AuthLoginResponseViewModel } from '../drive-server/services/auth/auth.types';
+
+export function registerAuthIPCHandlers(): void {
+  AuthIPCMain.handle(
+    'auth:login',
+    async (_event: IpcMainInvokeEvent, email: string) => {
+      const response = await driveServerModule.auth.login(email);
+      return response.fold<AuthLoginResponseViewModel>(
+        (err) => ({ success: false, error: err.message }),
+        (data) => ({ success: true, data })
+      );
+    }
+  );
+}

--- a/src/infra/ipc/auth-ipc-handlers.ts
+++ b/src/infra/ipc/auth-ipc-handlers.ts
@@ -1,7 +1,12 @@
 import { IpcMainInvokeEvent } from 'electron';
 import { driveServerModule } from '../drive-server/drive-server.module';
 import { AuthIPCMain } from './auth-ipc-main';
-import { AuthLoginResponseViewModel } from '../drive-server/services/auth/auth.types';
+import {
+  AuthAccessResponseViewModel,
+  AuthLoginResponseViewModel,
+  LoginAccessRequest,
+  LoginAccessResponse,
+} from '../drive-server/services/auth/auth.types';
 
 export function registerAuthIPCHandlers(): void {
   AuthIPCMain.handle(
@@ -11,6 +16,17 @@ export function registerAuthIPCHandlers(): void {
       return response.fold<AuthLoginResponseViewModel>(
         (err) => ({ success: false, error: err.message }),
         (data) => ({ success: true, data })
+      );
+    }
+  );
+
+  AuthIPCMain.handle(
+    'auth:access',
+    async (_event: IpcMainInvokeEvent, credentials: LoginAccessRequest) => {
+      const response = await driveServerModule.auth.access(credentials);
+      return response.fold<AuthAccessResponseViewModel>(
+        (err) => ({ success: false, error: err.message }),
+        (data: LoginAccessResponse) => ({ success: true, data })
       );
     }
   );

--- a/src/infra/ipc/auth-ipc-main.ts
+++ b/src/infra/ipc/auth-ipc-main.ts
@@ -1,0 +1,8 @@
+import { ipcMain } from 'electron';
+import { TypedIPC } from 'src/apps/shared/IPC/TypedIPC';
+import { ListenedEvents } from './auth-listened-events';
+import { EmittedEvents } from './auth-emitted-events';
+
+
+export type TAuthIPCMain = TypedIPC<ListenedEvents, EmittedEvents>;
+export const AuthIPCMain = ipcMain as unknown as TAuthIPCMain;

--- a/src/infra/ipc/auth-listened-events.ts
+++ b/src/infra/ipc/auth-listened-events.ts
@@ -1,0 +1,1 @@
+export type ListenedEvents = NonNullable<unknown>;


### PR DESCRIPTION
## What is Changed / Added
----
### **DriveServerModule**
- **`auth.login(email)`**  
  Calls the new **`/auth/login`** endpoint.
- **`auth.access({ email, password, tfa? })`**  
  Completes the second-step login through **`/auth/login/access`**.
- Both methods point to the **new base URL** (`NEW_DRIVE_URL`) and leverage the **Axios-based service layer**.

### **IPC & UI wiring**
- New IPC channel **`auth:access`** lets the renderer invoke `auth.access`.
- New IPC channel **`auth:login`** lets the renderer invoke `auth.login`.
- **Preload & renderer** now expose/use:
  ```ts
  window.electron.login(email);
  window.electron.access({ email, password, tfa });
