### PR TITLE
Feat: invalidate user session when log out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ clamAV/**
 
 # Http Client
 /http/*.env.json
+
+# Claude Code instructions
+CLAUDE.md

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,9 +8,14 @@
       "protocol": "inspector",
       "runtimeExecutable": "npm",
       "runtimeArgs": [
-        "run start:main --inspect=5858 --remote-debugging-port=9223"
+        "run", "start:main"
       ],
-      "preLaunchTask": "Start Webpack Dev"
+      "env": {
+        "NODE_OPTIONS": "--inspect=5858"
+      },
+      "preLaunchTask": "Start Webpack Dev",
+      "console": "integratedTerminal",
+      "skipFiles": ["<node_internals>/**"]
     },
     {
       "name": "Electron: Renderer",

--- a/src/apps/main/auth/handlers.ts
+++ b/src/apps/main/auth/handlers.ts
@@ -6,6 +6,7 @@ import { applicationOpened } from '../analytics/service';
 import eventBus from '../event-bus';
 import { setupRootFolder } from '../virtual-root-folder/service';
 import { getWidget } from '../windows/widget';
+import { AuthModule } from '../../../features/auth/auth.module';
 import { createTokenSchedule } from './refresh-token/refresh-token';
 import {
   canHisConfigBeRestored,
@@ -13,7 +14,6 @@ import {
   getHeaders,
   getNewApiHeaders,
   getUser,
-  logout,
   obtainToken,
   setCredentials,
   tokensArePresent,
@@ -54,7 +54,7 @@ ipcMain.handle('get-token', () => {
 export function onUserUnauthorized() {
   eventBus.emit('USER_WAS_UNAUTHORIZED');
 
-  logout();
+  AuthModule.logout();
   Logger.info('[AUTH] User has been logged out because it was unauthorized');
   setIsLoggedIn(false);
 }
@@ -85,7 +85,7 @@ ipcMain.on('user-logged-out', () => {
 
   setIsLoggedIn(false);
 
-  logout();
+  AuthModule.logout();
 });
 
 eventBus.on('APP_IS_READY', async (): Promise<void> => {

--- a/src/apps/main/auth/service.ts
+++ b/src/apps/main/auth/service.ts
@@ -2,7 +2,7 @@ import { safeStorage } from 'electron';
 import Logger from 'electron-log';
 
 import packageConfig from '../../../../package.json';
-import ConfigStore, { defaults, fieldsToSave } from '../config';
+import ConfigStore from '../config';
 import { User } from '../types';
 import { Delay } from '../../shared/Delay';
 
@@ -173,18 +173,6 @@ export function obtainTokens(): Array<string> {
   return tokensKeys.map(obtainToken);
 }
 
-function resetCredentials() {
-  for (const field of [
-    'mnemonic',
-    'userData',
-    'bearerToken',
-    'bearerTokenEncrypted',
-    'newToken',
-  ] as const) {
-    ConfigStore.set(field, defaults[field]);
-  }
-}
-
 export function canHisConfigBeRestored(uuid: string) {
   const savedConfigs = ConfigStore.get('savedConfigs');
 
@@ -200,48 +188,4 @@ export function canHisConfigBeRestored(uuid: string) {
   }
 
   return true;
-}
-
-export function logout() {
-  Logger.info('Logging out');
-
-  saveConfig();
-  resetConfig();
-  resetCredentials();
-  Logger.info('[AUTH] User logged out');
-}
-
-function saveConfig() {
-  const user = getUser();
-  if (!user) {
-    return;
-  }
-
-  const { uuid } = user;
-
-  const savedConfigs = ConfigStore.get('savedConfigs');
-
-  const configToSave: any = {};
-
-  for (const field of fieldsToSave) {
-    const value = ConfigStore.get(field);
-    configToSave[field] = value;
-  }
-  ConfigStore.set('savedConfigs', {
-    ...savedConfigs,
-    [uuid]: configToSave,
-  });
-}
-
-const keepFields: Array<keyof typeof defaults> = [
-  'preferedLanguage',
-  'lastOnboardingShown',
-];
-
-function resetConfig() {
-  for (const field of fieldsToSave) {
-    if (!keepFields.includes(field)) {
-      ConfigStore.set(field, defaults[field]);
-    }
-  }
 }

--- a/src/context/shared/domain/Fold.ts
+++ b/src/context/shared/domain/Fold.ts
@@ -1,0 +1,8 @@
+import { Either } from './Either';
+
+export const fold = <L, R, T>(
+  either: Either<L, R>,
+  onLeft: (error: L) => T,
+  onRight: (value: R) => T
+): T =>
+  either.isLeft() ? onLeft(either.getLeft()) : onRight(either.getRight());

--- a/src/features/auth/auth.module.ts
+++ b/src/features/auth/auth.module.ts
@@ -1,0 +1,6 @@
+import { logout } from './services/logout.service';
+
+
+export const AuthModule = {
+  logout,
+};

--- a/src/features/auth/services/logout.service.ts
+++ b/src/features/auth/services/logout.service.ts
@@ -1,0 +1,76 @@
+import Logger from 'electron-log';
+import { driveServerModule } from '../../../infra/drive-server/drive-server.module';
+import { fold } from '../../../context/shared/domain/Fold';
+import configStore, { defaults, fieldsToSave } from '../../../apps/main/config';
+import { User } from '../../../apps/main/types';
+
+const keepFields: Array<keyof typeof defaults> = [
+  'preferedLanguage',
+  'lastOnboardingShown',
+];
+
+function resetCredentials(): void {
+  for (const field of [
+    'mnemonic',
+    'userData',
+    'bearerToken',
+    'bearerTokenEncrypted',
+    'newToken',
+  ] as const) {
+    configStore.set(field, defaults[field]);
+  }
+}
+
+function getUser(): User | null {
+  const user = configStore.get('userData');
+
+  return user && Object.keys(user).length ? user : null;
+}
+
+function saveConfig(): void {
+  const user = getUser();
+  if (!user) {
+    return;
+  }
+
+  const { uuid } = user;
+
+  const savedConfigs = configStore.get('savedConfigs');
+
+  const configToSave: any = {};
+
+  for (const field of fieldsToSave) {
+    const value = configStore.get(field);
+    configToSave[field] = value;
+  }
+  configStore.set('savedConfigs', {
+    ...savedConfigs,
+    [uuid]: configToSave,
+  });
+}
+
+function resetConfig(): void {
+  for (const field of fieldsToSave) {
+    if (!keepFields.includes(field)) {
+      configStore.set(field, defaults[field]);
+    }
+  }
+}
+
+export function logout() {
+  driveServerModule.auth.logout().then((result) => {
+    fold(
+      result,
+      (error) => {
+        Logger.error('[AUTH] Error during server logout:', error);
+      },
+      (success) => {
+        Logger.info('[AUTH] Server logout successful:', success);
+      }
+    );
+  });
+  saveConfig();
+  resetConfig();
+  resetCredentials();
+  Logger.info('[AUTH] User logged out');
+}

--- a/src/infra/drive-server/client/drive-server.client.instance.test.ts
+++ b/src/infra/drive-server/client/drive-server.client.instance.test.ts
@@ -1,14 +1,16 @@
 import { createClient } from '../drive-server.client';
 import Bottleneck from 'bottleneck';
 import eventBus from '../../../apps/main/event-bus';
-import { logout } from '../../../apps/main/auth/service';
+import { AuthModule } from '../../../features/auth/auth.module';
 
 jest.mock('../drive-server.client', () => ({
   createClient: jest.fn(() => ({}))
 }));
 
-jest.mock('../../../apps/main/auth/service', () => ({
-  logout: jest.fn()
+jest.mock('../../../features/auth/auth.module', () => ({
+  AuthModule: {
+    logout: jest.fn()
+  }
 }));
 
 jest.mock('../../../apps/main/event-bus', () => ({
@@ -48,7 +50,7 @@ describe('driveServerClient instance', () => {
     clientOptionsArg.onUnauthorized();
 
     expect(eventBus.emit).toHaveBeenCalledWith('USER_WAS_UNAUTHORIZED');
-    expect(logout).toHaveBeenCalled();
+    expect(AuthModule.logout).toHaveBeenCalled();
   });
 
   it('should use process.env.NEW_DRIVE_URL as baseUrl', async () => {

--- a/src/infra/drive-server/client/drive-server.client.instance.ts
+++ b/src/infra/drive-server/client/drive-server.client.instance.ts
@@ -1,13 +1,13 @@
 import { paths } from '../../schemas';
 import Bottleneck from 'bottleneck';
-import { logout } from '../../../apps/main/auth/service';
+import { AuthModule } from '../../../features/auth/auth.module';
 import eventBus from '../../../apps/main/event-bus';
 import { ClientOptions, createClient } from '../drive-server.client';
 
 
 function handleOnUserUnauthorized(): void {
   eventBus.emit('USER_WAS_UNAUTHORIZED');
-  logout();
+  AuthModule.logout();
 }
 
 const limiter = new Bottleneck({

--- a/src/infra/drive-server/services/auth/auth.service.ts
+++ b/src/infra/drive-server/services/auth/auth.service.ts
@@ -107,4 +107,34 @@ export class AuthService {
       return left(error);
     }
   }
+
+  async logout(): Promise<Either<Error, boolean>> {
+    const headers = getNewApiHeaders();
+    try {
+      const response = await authClient.GET('/auth/logout', {
+        headers,
+      });
+
+      if (!response.data) {
+        logger.error({
+          msg: 'Logout request was not successful',
+          tag: 'AUTH',
+          attributes: { endpoint: '/auth/logout' },
+        });
+        return left(new Error('Logout request was not successful'));
+      }
+      return right(true);
+    } catch (err) {
+      const error = mapError(err);
+      logger.error({
+        msg: 'Logout request threw an exception',
+        tag: 'AUTH',
+        error: error,
+        attributes: {
+          endpoint: '/auth/logout',
+        },
+      });
+      return left(error);
+    }
+  }
 }


### PR DESCRIPTION
## What is Changed / Added
Now, when a user logs out of the app, we will send a request to invalidate the session token, forcing to log in again in order to retrieve new session tokens.

## Why
An attacker who successfully possess the config of the application or JWT token will be able to use it to gain access to the application. Therefore we **must** invalidate the token when logout