### PR TITLE
fix multiple accounts virtual drive error

### DIFF
--- a/src/apps/drive/fuse/FuseApp.ts
+++ b/src/apps/drive/fuse/FuseApp.ts
@@ -146,11 +146,21 @@ export class FuseApp extends EventEmitter {
   }
 
   async stop(): Promise<void> {
-    //no-op
+    if (this._fuse && this.status === 'MOUNTED') {
+      try {
+        await unmountPromise(this._fuse);
+        this.status = 'UNMOUNTED';
+        Logger.info('[FUSE] unmounted');
+      } catch (error) {
+        Logger.error('[FUSE] unmount error:', error);
+      }
+    }
   }
 
   async clearCache(): Promise<void> {
     await this.container.get(StorageClearer).run();
+    await this.container.get(FileRepositorySynchronizer).clear();
+    await this.container.get(FolderRepositorySynchronizer).clear();
   }
 
   async update(): Promise<void> {

--- a/src/apps/main/auth/handlers.ts
+++ b/src/apps/main/auth/handlers.ts
@@ -52,9 +52,8 @@ ipcMain.handle('get-token', () => {
 });
 
 export function onUserUnauthorized() {
-  eventBus.emit('USER_WAS_UNAUTHORIZED');
-
   AuthModule.logout();
+  eventBus.emit('USER_LOGGED_OUT');
   Logger.info('[AUTH] User has been logged out because it was unauthorized');
   setIsLoggedIn(false);
 }
@@ -81,6 +80,7 @@ ipcMain.on('user-logged-in', async (_, data: AccessResponse) => {
 });
 
 ipcMain.on('user-logged-out', () => {
+  AuthModule.logout();
   eventBus.emit('USER_LOGGED_OUT');
 
   setIsLoggedIn(false);

--- a/src/apps/main/windows/auth.ts
+++ b/src/apps/main/windows/auth.ts
@@ -11,6 +11,13 @@ export const getAuthWindow = () => {
 };
 
 export const createAuthWindow = async () => {
+  // Check if auth window already exists and is not destroyed
+  if (authWindow && !authWindow.isDestroyed()) {
+    // If window exists, focus it and return early
+    authWindow.focus();
+    return;
+  }
+
   authWindow = new BrowserWindow({
     width: 300,
     height: 450,

--- a/src/context/virtual-drive/files/application/FileRepositorySynchronizer.ts
+++ b/src/context/virtual-drive/files/application/FileRepositorySynchronizer.ts
@@ -66,6 +66,10 @@ export class FileRepositorySynchronizer {
     }
   }
 
+  async clear(): Promise<void> {
+    await this.repository.clear();
+  }
+
   async run(files: Array<File>): Promise<boolean> {
     // Resets the repository since replaced files become duplicated as
     // not all applications use the replace endpoint

--- a/src/context/virtual-drive/folders/application/FolderRepositorySynchronizer/FolderRepositorySynchronizer.ts
+++ b/src/context/virtual-drive/folders/application/FolderRepositorySynchronizer/FolderRepositorySynchronizer.ts
@@ -6,7 +6,13 @@ import { FolderRepository } from '../../domain/FolderRepository';
 export class FolderRepositorySynchronizer {
   constructor(private readonly repository: FolderRepository) {}
 
+  async clear(): Promise<void> {
+    await this.repository.clear();
+  }
+
   async run(remoteFolders: Array<Folder>): Promise<void> {
+    await this.repository.clear();
+
     const currentFolders = await this.repository.all();
 
     const remoteFoldersIds = new Set(remoteFolders.map((folder) => folder.id));

--- a/src/context/virtual-drive/folders/domain/FolderRepository.ts
+++ b/src/context/virtual-drive/folders/domain/FolderRepository.ts
@@ -14,4 +14,6 @@ export abstract class FolderRepository {
   abstract delete(id: Folder['id']): Promise<void>;
 
   abstract update(folder: Folder): Promise<void>;
+
+  abstract clear(): Promise<void>;
 }

--- a/src/context/virtual-drive/folders/infrastructure/InMemoryFolderRepository.ts
+++ b/src/context/virtual-drive/folders/infrastructure/InMemoryFolderRepository.ts
@@ -73,4 +73,8 @@ export class InMemoryFolderRepository implements FolderRepository {
 
     return this.add(folder);
   }
+
+  async clear(): Promise<void> {
+    this.folders.clear();
+  }
 }

--- a/src/infra/drive-server/services/backup/backup.service.ts
+++ b/src/infra/drive-server/services/backup/backup.service.ts
@@ -350,11 +350,14 @@ export class BackupService {
     deviceName: string
   ): Promise<Either<Error, Device>> {
     try {
-      const response = await driveServerClient.PATCH('/backup/v2/devices/{deviceId}', {
-        headers: getNewApiHeaders(),
-        body: { deviceName },
-        path: { deviceId: deviceIdentifier },
-      });
+      const response = await driveServerClient.PATCH(
+        '/backup/v2/devices/{deviceId}',
+        {
+          headers: getNewApiHeaders(),
+          body: { name: deviceName },
+          path: { deviceId: deviceIdentifier },
+        }
+      );
       if (!response.data) {
         const error = new Error('Update device by identifier request was not successful');
         logger.error({

--- a/src/infra/schemas.d.ts
+++ b/src/infra/schemas.d.ts
@@ -1774,6 +1774,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/users/avatar/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Refresh avatar token */
+        get: operations["UserController_refreshAvatarUser"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/users/password": {
         parameters: {
             query?: never;
@@ -3659,6 +3676,10 @@ export interface components {
             /** @description User information */
             user: components["schemas"]["RefreshTokenUserResponseDto"];
         };
+        RefreshUserAvatarDto: {
+            /** @description A new avatar URL for the given user */
+            avatar: string;
+        };
         UpdatePasswordDto: {
             /**
              * @description Current password
@@ -3811,6 +3832,11 @@ export interface components {
         };
         LegacyRecoverAccountDto: {
             /**
+             * @description Base64 encoded temporary auth token
+             * @example temporary_auth_token
+             */
+            token: string;
+            /**
              * @description New user pass hashed
              * @example hashed_password
              */
@@ -3919,11 +3945,37 @@ export interface components {
         FuzzySearchResults: {
             data: components["schemas"]["FuzzySearchResult"][];
         };
-        /**
-         * @description Device platform
-         * @enum {string}
-         */
+        /** @enum {string} */
         DevicePlatform: "win32" | "darwin" | "linux" | "android";
+        DeviceAsFolder: {
+            type: string;
+            id: number;
+            parentId: number;
+            parentUuid: string;
+            name: string;
+            parent: components["schemas"]["Folder"];
+            bucket: string;
+            userId: number;
+            encryptVersion: string;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+            uuid: string;
+            plainName: string;
+            size: number;
+            /** Format: date-time */
+            creationTime: string;
+            /** Format: date-time */
+            modificationTime: string;
+            /** @enum {string} */
+            status: "EXISTS" | "TRASHED" | "DELETED";
+            removed: boolean;
+            deleted: boolean;
+            hasBackups: boolean;
+            /** Format: date-time */
+            lastBackupAt: string;
+        };
         DeviceDto: {
             /** @example 7 */
             id: number;
@@ -3951,11 +4003,17 @@ export interface components {
             hostname: string;
             /** @example 077e1ec6-9272-4719-ae1a-2ae35883a09e */
             folderUuid: string;
-            /** @example 2025-07-10T20:14:04.784Z */
+            /**
+             * Format: date-time
+             * @example 2025-07-10T20:14:04.784Z
+             */
             createdAt: string;
-            /** @example 2025-07-10T20:14:04.784Z */
+            /**
+             * Format: date-time
+             * @example 2025-07-10T20:14:04.784Z
+             */
             updatedAt: string;
-            folder?: components["schemas"]["DeviceAsFolder"];
+            folder: components["schemas"]["DeviceAsFolder"] | null;
         };
         CreateDeviceAndFolderDto: {
             /**
@@ -4012,38 +4070,10 @@ export interface components {
         CreateDeviceAsFolderDto: {
             deviceName: string;
         };
-        DeviceAsFolder: {
-            type: string;
-            id: number;
-            parentId: number;
-            parentUuid: string;
-            name: string;
-            parent: components["schemas"]["Folder"];
-            bucket: string;
-            userId: number;
-            encryptVersion: string;
-            /** Format: date-time */
-            createdAt: string;
-            /** Format: date-time */
-            updatedAt: string;
-            uuid: string;
-            plainName: string;
-            size: number;
-            /** Format: date-time */
-            creationTime: string;
-            /** Format: date-time */
-            modificationTime: string;
-            /** @enum {string} */
-            status: "EXISTS" | "TRASHED" | "DELETED";
-            removed: boolean;
-            deleted: boolean;
-            hasBackups: boolean;
-            /** Format: date-time */
-            lastBackupAt: string;
-        };
-        ItemToTrash: {
+        ItemToTrashDto: {
             /**
-             * @description Id of file or folder
+             * @deprecated
+             * @description Id of file or folder (deprecated in favor of uuid)
              * @example 4
              */
             id: string | null;
@@ -4055,16 +4085,36 @@ export interface components {
             /**
              * @description Type of item: file or folder
              * @example file
+             * @enum {string}
              */
-            type: string;
+            type: "file" | "folder";
         };
         MoveItemsToTrashDto: {
             /** @description Array of items with files and folders ids */
-            items: components["schemas"]["ItemToTrash"][];
+            items: components["schemas"]["ItemToTrashDto"][];
+        };
+        DeleteItemDto: {
+            /**
+             * @deprecated
+             * @description Id of file or folder (deprecated in favor of uuid)
+             * @example 4
+             */
+            id: string | null;
+            /**
+             * @description Uuid of file or folder
+             * @example 79a88429-b45a-4ae7-90f1-c351b6882670
+             */
+            uuid: string;
+            /**
+             * @description Type of item: file or folder
+             * @example file
+             * @enum {string}
+             */
+            type: "file" | "folder";
         };
         DeleteItemsDto: {
             /** @description Array of items with files and folders ids */
-            items: string[];
+            items: components["schemas"]["DeleteItemDto"][];
         };
         LoginDto: {
             /**
@@ -7161,6 +7211,26 @@ export interface operations {
             };
         };
     };
+    UserController_refreshAvatarUser: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Returns a new avatar URL */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RefreshUserAvatarDto"];
+                };
+            };
+        };
+    };
     UserController_updatePassword: {
         parameters: {
             query?: never;
@@ -7291,9 +7361,7 @@ export interface operations {
     };
     UserController_requestLegacyAccountRecovery: {
         parameters: {
-            query: {
-                token: string;
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
@@ -7729,9 +7797,12 @@ export interface operations {
     BackupController_getDevicesAndFolders: {
         parameters: {
             query: {
-                platform: string;
-                key: string;
-                hostname: string;
+                /** @description Device platform */
+                platform?: components["schemas"]["DevicePlatform"];
+                /** @description OS Installation unique identifier */
+                key?: string;
+                /** @description Device hostname */
+                hostname?: string;
                 limit: number;
                 offset: number;
             };


### PR DESCRIPTION
 What is Changed / Added

  ---
  Summary

  Fixed account switching issue where files from the previous account would
  briefly appear when switching to a new account. This was caused by incomplete
  FUSE filesystem cleanup during logout.

  Technical Changes

  - Implemented proper FUSE unmounting: Added actual unmount logic to
  FuseApp.stop() method (was previously a no-op)
  - Enhanced cache clearing: Updated FuseApp.clearCache() to clear both storage
  files and virtual drive repositories
  - Added repository clearing methods: Implemented clear() methods in
  InMemoryFolderRepository, FileRepositorySynchronizer, and
  FolderRepositorySynchronizer

  Why

  ---
  The Problem (User Perspective)

  When users switched between different Internxt accounts (from Account A to
  Account B), they would briefly see files and folders from Account A before
  Account B's content loaded. This created confusion and potential privacy
  concerns as users could momentarily see data from the wrong account.

  The Technical Root Cause

  This issue emerged after recent authentication system changes.
  Previously, the logout process immediately cleared user state, which made FUSE
  filesystem operations fail gracefully. The new AuthModule.logout() system had
  different cleanup patterns, exposing that the FUSE virtual filesystem was never
  being properly unmounted during account switches.

  The core problems were:
  1. FUSE filesystem stayed mounted: The old account's virtual drive remained
  active during account switching
  2. Incomplete data clearing: Folder information from the previous account
  persisted in memory
  3. Mount conflicts: New account login attempted to mount on an already-occupied
  mountpoint
  4. Race conditions: Cleanup processes ran in parallel instead of sequentially

  Why This Worked Before

  The old logout system (logout() function) immediately cleared all user
  credentials and state. This caused FUSE operations to fail silently due to
  missing authentication context, effectively hiding the fact that the filesystem
  was never properly unmounted. When we modernized the authentication system, this
   masking effect was removed, revealing the underlying cleanup issues.

  Impact of the Fix
  - Clean account switching: Users now see only their current account's files
  during transitions
  - No more error messages: Eliminated "Mountpoint in use" and "Resource is
  closed" FUSE errors
  - Better security: Complete isolation between different user accounts
  - Improved reliability: Proper cleanup prevents state contamination between
  sessions