### PR TITLE
Add gh action for enabling 500 loc

### DIFF
--- a/.github/workflows/check_pr_size.yml
+++ b/.github/workflows/check_pr_size.yml
@@ -1,0 +1,43 @@
+name: Check PR size
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check_pr_size:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Calculate changed lines
+        id: diff_check
+        run: |
+          # Get the target branch commit (base) and the PR branch commit (head)
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          echo "Base SHA: $BASE_SHA"
+          echo "Head SHA: $HEAD_SHA"
+          # Compute the merge base between the two branches
+          MERGE_BASE=$(git merge-base "$HEAD_SHA" "$BASE_SHA")
+          echo "Merge Base: $MERGE_BASE"
+          # Calculate added and deleted lines between the merge base and the head commit
+          TOTAL_CHANGED=$(git diff --numstat "$MERGE_BASE" "$HEAD_SHA" \
+            | grep -Ev "(yarn.lock|schemas.d.ts)" \
+            | awk '{ added += $1; deleted += $2 } END { print added + deleted }')
+          # Default to 0 if nothing is output
+          TOTAL_CHANGED=${TOTAL_CHANGED:-0}
+          echo "Total changed lines: $TOTAL_CHANGED"
+          # Make the total available for later steps
+          echo "total=$TOTAL_CHANGED" >> "$GITHUB_OUTPUT"
+      - name: Fail if too many changes
+        if: ${{ steps.diff_check.outputs.total > 500 }}
+        run: |
+          echo "PR has ${{ steps.diff_check.outputs.total }} changed lines, which exceeds the 500-line limit."
+          echo "Please reduce the size of this PR."
+          exit 1


### PR DESCRIPTION
## What is Changed / Added
Added GitHub Action workflow .github/workflows/check_pr_size.yml that
  automatically checks PR size
  - Enforces maximum of 500 lines of changes per pull request
  - Excludes auto-generated files (yarn.lock, schemas.d.ts) from line count
  - Fails CI if PR exceeds the limit with clear error messaging
----
## Why
Large pull requests are harder to review thoroughly, increase the likelihood
   of bugs, and slow down the development process. By enforcing a 500-line limit,
   we encourage:

  - Better code review quality through smaller, focused changes
  - Faster review cycles and reduced reviewer fatigue
  - Easier identification of issues and conflicts
  - More atomic commits that are easier to understand and revert if needed

  This automated check ensures consistency across all contributors and helps
  maintain our code quality standards.
