### PR TITLE
fix: antivirus spamming logs trying to start

### DIFF
--- a/src/apps/main/background-processes/antivirus/try-setup-antivirus-ipc-and-initialize.ts
+++ b/src/apps/main/background-processes/antivirus/try-setup-antivirus-ipc-and-initialize.ts
@@ -1,0 +1,14 @@
+import { logger } from '@internxt/drive-desktop-core/build/backend';
+import { setupAntivirusIpc } from './setupAntivirusIPC';
+import { getAntivirusManager } from '../../antivirus/antivirusManager';
+
+export async function trySetupAntivirusIpcAndInitialize() {
+    try {
+    logger.debug({ tag: 'ANTIVIRUS', msg: '[Main] Setting up antivirus IPC handlers'});
+    setupAntivirusIpc();
+    logger.debug({ msg: '[Main] Antivirus IPC handlers setup complete'});
+    await getAntivirusManager().initialize();
+  } catch (error) {
+    logger.error({ tag: 'ANTIVIRUS', msg: '[Main] Error setting up antivirus:', error });
+  }
+}

--- a/src/apps/main/main.ts
+++ b/src/apps/main/main.ts
@@ -68,6 +68,7 @@ import { registerAvailableUserProductsHandlers } from './payments/ipc/AvailableU
 import { getAntivirusManager } from './antivirus/antivirusManager';
 import { registerAuthIPCHandlers } from '../../infra/ipc/auth-ipc-handlers';
 import { logger } from '@internxt/drive-desktop-core/build/backend';
+import { trySetupAntivirusIpcAndInitialize } from './background-processes/antivirus/try-setup-antivirus-ipc-and-initialize';
 
 const gotTheLock = app.requestSingleInstanceLock();
 
@@ -142,15 +143,6 @@ app
 
 eventBus.on('WIDGET_IS_READY', () => {
   setUpBackups();
-
-  try {
-    logger.debug({ msg: '[Main] Setting up antivirus IPC handlers'});
-    setupAntivirusIpc();
-    logger.debug({ msg: '[Main] Antivirus IPC handlers setup complete'});
-    void getAntivirusManager().initialize();
-  } catch (error) {
-    logger.error({ msg: '[Main] Error setting up antivirus:', error });
-  }
 });
 
 eventBus.on('USER_LOGGED_IN', async () => {
@@ -184,7 +176,7 @@ eventBus.on('USER_LOGGED_IN', async () => {
 
     setCleanUpFunction(stopSyncEngineWatcher);
 
-    void getAntivirusManager().initialize();
+    await trySetupAntivirusIpcAndInitialize();
   } catch (error) {
     logger.error({ msg: 'Error on main process while handling USER_LOGGED_IN event:', error });
     reportError(error as Error);

--- a/src/apps/main/payments/handler.ts
+++ b/src/apps/main/payments/handler.ts
@@ -1,13 +1,30 @@
 import eventBus from '../event-bus';
 import { buildPaymentsService } from './builder';
 import Logger from 'electron-log';
+import { AvailableProducts } from '@internxt/sdk/dist/drive/payments/types';
+
+function areProductsEqual({
+  stored,
+  fetched
+}: {
+  stored: AvailableProducts['featuresPerService'] | undefined;
+  fetched: AvailableProducts['featuresPerService'];
+}): boolean {
+  if (!stored) return false;
+
+  return stored.antivirus === fetched.antivirus && stored.backups === fetched.backups;
+}
 
 export async function getUserAvailableProductsAndStore() {
   try {
     const paymentsService = buildPaymentsService();
-    const products = await paymentsService.getAvailableProducts();
-    void paymentsService.storeUserProducts(products);
-    eventBus.emit('USER_AVAILABLE_PRODUCTS_UPDATED', products);
+    const fetched = await paymentsService.getAvailableProducts();
+    const stored = paymentsService.getStoredUserProducts();
+
+    if (!areProductsEqual({ stored, fetched })) {
+      void paymentsService.storeUserProducts(fetched);
+      eventBus.emit('USER_AVAILABLE_PRODUCTS_UPDATED', fetched);
+    }
   } catch (err) {
     Logger.error(`[PRODUCTS] Failed to get user available products with error: ${err}`);
   }

--- a/src/apps/main/payments/service.ts
+++ b/src/apps/main/payments/service.ts
@@ -5,13 +5,19 @@ import configStore from '../config';
 export class PaymentsService {
   constructor(private readonly payments: Payments) {}
 
-  async getAvailableProducts(): Promise<AvailableProducts['featuresPerService']> {
+  async getAvailableProducts(): Promise<
+    AvailableProducts['featuresPerService']
+  > {
     const products = await this.payments.checkUserAvailableProducts();
 
     return products.featuresPerService;
   }
 
-  async storeUserProducts(products: AvailableProducts['featuresPerService']): Promise<void> {
+  getStoredUserProducts(): AvailableProducts['featuresPerService'] | undefined {
+    return configStore.get('availableUserProducts');
+  }
+
+  storeUserProducts(products: AvailableProducts['featuresPerService']): void {
     configStore.set('availableUserProducts', products);
   }
 }

--- a/src/apps/main/preload.js
+++ b/src/apps/main/preload.js
@@ -1,6 +1,6 @@
 const { contextBridge, ipcRenderer } = require('electron');
 const path = require('path');
-import { logger } from '@internxt/drive-desktop-core/build/backend';
+const { logger } = require('@internxt/drive-desktop-core/build/backend');
 
 contextBridge.exposeInMainWorld('electron', {
   getConfigKey(key) {


### PR DESCRIPTION
## What is Changed / Added
Previously, when the event of `GET_USER_AVAILABLE_PRODUCTS` was emmited, we would always try to start the antivirus no matter if the user had it activated or not, causing a lot of logs of this matter being shown.

Now, on the event of `GET_USER_AVAILABLE_PRODUCTS`, we will only store and then try to to activate the antivirus only if the object has changed and the antivirus product has been activated
