### PR TITLE
feat: migrate backuplist from configstore to accept folderUuid

### DIFF
--- a/src/apps/main/device/fetch-folder-by-id.ts
+++ b/src/apps/main/device/fetch-folder-by-id.ts
@@ -1,0 +1,31 @@
+import { components } from '../../../infra/schemas';
+import { Result } from '../../../context/shared/domain/Result';
+import { getNewApiHeaders } from '../auth/service';
+
+export async function fetchFolderById(
+  folderId: string
+): Promise<Result<components['schemas']['GetFolderContentDto'], Error>> {
+  try {
+    const res = await fetch(
+      `${process.env.NEW_DRIVE_URL}/folders/content/${folderId}`,
+      {
+        method: 'GET',
+        headers: getNewApiHeaders(),
+      }
+    );
+    if (!res.ok) {
+      return { error: new Error('Unsuccessful request to fetch folder') };
+    }
+
+    const responseBody: components['schemas']['GetFolderContentDto'] = await res
+      .json()
+      .catch(() => null);
+
+    if (responseBody?.deleted || responseBody?.removed) {
+      return { error: new Error('Folder does not exist') };
+    }
+    return { data: responseBody };
+  } catch (error) {
+    return { error: new Error('Unsuccessful request to fetch folder') };
+  }
+}

--- a/src/apps/main/device/migrate-backup-entry-if-needed.ts
+++ b/src/apps/main/device/migrate-backup-entry-if-needed.ts
@@ -1,0 +1,55 @@
+import { logger } from '@internxt/drive-desktop-core/build/backend/core/logger/logger';
+import configStore from '../config';
+import { fetchFolderById } from './fetch-folder-by-id';
+
+/*
+ v2.4.10 Alexis Mora
+ This is a function that migrates the backup object withn the record in 'backupList' to include the folder UUID.
+ since we are phasing out the folder ID, we need to ensure that all backups have a UUID.
+ This function and the whole migration should be removed 1 year at most after the release of v2.4.10.
+*/
+export async function migrateBackupEntryIfNeeded(
+  pathname: string,
+  backup: {
+    enabled: boolean;
+    folderId: number;
+    folderUuid: string;
+  }
+): Promise<{
+  enabled: boolean;
+  folderId: number;
+  folderUuid: string;
+}> {
+  if (!backup.folderUuid) {
+    try {
+      logger.debug({
+        msg: `[BACKUP MIGRATION] Migrating backup entry for ${pathname}, fetching UUID for folder ID ${backup.folderId}`,
+      });
+
+      const res = await fetchFolderById(backup.folderId.toString());
+
+      if (res.data) {
+        const { data } = res;
+        backup.folderUuid = data.uuid;
+
+        const backupList = configStore.get('backupList');
+        backupList[pathname] = backup;
+        configStore.set('backupList', backupList);
+
+        logger.debug({
+          msg: `[BACKUP MIGRATION] Successfully migrated backup entry for ${pathname} with UUID ${data.uuid}`,
+        });
+      } else {
+        logger.warn({
+          msg: `[BACKUP MIGRATION] Failed to fetch folder details for ${pathname}, error: ${res.error}`,
+        });
+      }
+    } catch (error) {
+      logger.error({
+        msg: `[BACKUP MIGRATION] Failed to migrate backup UUID for ${pathname}:`,
+        error,
+      });
+    }
+  }
+  return backup;
+}


### PR DESCRIPTION
The `backupList` property from the configstore was saving only the backup id, since we are phasing out of this functionality, we will need to do a migration process to store also the folder uuid from the previous, stored backups.
Thats why im creating this `migrateBackupEntryIfNeeded` function that gets a saved backupList object and a pathname and if there is no uuid saved, we retrieve it again from id and then save the backup's uuid