### PR TITLE
Fix: ensure force storage when checking user available products on login

### DIFF
--- a/src/backend/features/payments/ipc/register-available-user-products-handlers.ts
+++ b/src/backend/features/payments/ipc/register-available-user-products-handlers.ts
@@ -24,7 +24,7 @@ export function registerAvailableUserProductsHandlers() {
       tag: 'PRODUCTS',
       msg: 'User Logged in, checkin product availability',
     });
-    void getUserAvailableProductsAndStore();
+    void getUserAvailableProductsAndStore({ forceStorage: true });
   });
 
   eventBus.on('GET_USER_AVAILABLE_PRODUCTS', () => {


### PR DESCRIPTION
## What is Changed / Added
----
There were cache issues when switching between accounts in the application, so it was decided to force an update upon login to avoid using the available products parameter from another acco
## Why
