### PR TITLE
fix: delay destruction of auth window to prevent potential errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internxt",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "author": "Internxt <hello@internxt.com>",
   "description": "Internxt Drive client UI",
   "license": "AGPL-3.0",

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internxt",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Internxt Drive client UI",
   "main": "./dist/main/main.js",
   "author": "Internxt <hello@internxt.com>",

--- a/src/apps/main/main.ts
+++ b/src/apps/main/main.ts
@@ -166,7 +166,12 @@ eventBus.on('USER_LOGGED_IN', async () => {
       setBoundsOfWidgetByPath(widget, tray);
     }
 
-    getAuthWindow()?.destroy();
+    setTimeout(() => {
+      const authWin = getAuthWindow();
+      if (authWin && !authWin.isDestroyed()) {
+        authWin.destroy();
+      }
+    }, 300);
 
     const lastOnboardingShown = configStore.get('lastOnboardingShown');
 


### PR DESCRIPTION
📝 Technical Description of the Issue and Why setTimeout Is a Good Solution

The visual artifact (a black rectangle remaining on screen) occurred because the authentication window was being destroyed at an unsafe moment in the Electron rendering lifecycle. Although the window was hidden using hide(), the call to destroy() was executed before the new onboarding window had finished rendering and become ready to display.

In Electron, windows created with show: false go through several internal steps before they are actually visible:

The BrowserWindow is created.

loadURL() loads and builds the renderer content.

The first paint occurs.

The window emits ready-to-show, after which calling show() becomes safe.

If an existing window is destroyed before the new window reaches its ready-to-show stage, the GPU compositor briefly has no valid surface to render. This leads to a known Electron issue where a “ghost window” or black rectangle appears momentarily on screen.

Introducing a short setTimeout (typically 50–200 ms) before destroying the auth window gives Electron enough time to:

Process the pending show() call for the onboarding window

Complete the initial render and GPU composition pass

Ensure that at least one valid window surface exists before tearing down the previous one

This delay is not a hack; it is a commonly recommended practice within the Electron community when transitioning between windows—especially when using hidden windows, frameless windows (frame: false), or transparent windows, which are more susceptible to rendering artifacts.

In summary, the setTimeout provides the necessary synchronization to ensure a clean visual transition between windows and prevents the compositor from entering an invalid state during window destruction.