### PR TITLE
fix: handle EPIPE errors in uncaughtException to prevent infinite logging loops

### DIFF
--- a/src/apps/main/main.ts
+++ b/src/apps/main/main.ts
@@ -235,7 +235,9 @@ process.on('uncaughtException', (error) => {
   } else {
     try {
       logger.error({ msg: 'Uncaught exception in main process: ', error });
-    } catch {}
+    } catch {
+      return;
+    }
   }
 });
 


### PR DESCRIPTION
## What is Changed / Added
----
## Why
Valentyna encountered a case where the application closes due to Linux system-level issues unrelated to the application itself. When this occurs, Electron enters an inconsistent state: the main process continues running but stdout is already closed, creating an infinite loop where the application repeatedly attempts to write to the logs but never succeeds.
