### PR TITLE
feat: fix retry sync button

### DIFF
--- a/src/apps/main/interface.d.ts
+++ b/src/apps/main/interface.d.ts
@@ -102,6 +102,7 @@ export interface IElectronAPI {
   onBackupFatalErrorsChanged(fn: (backupErrors: Array<BackupErrorRecord>) => void): () => void;
   getBackupFatalErrors(): Promise<Array<BackupErrorRecord>>;
   onBackupProgress(func: (value: number) => void): () => void;
+  startRemoteSync(): Promise<void>;
 }
 
 declare global {

--- a/src/apps/main/remote-sync/RemoteSyncManager.ts
+++ b/src/apps/main/remote-sync/RemoteSyncManager.ts
@@ -89,6 +89,9 @@ export class RemoteSyncManager {
     }
     this.totalFilesSynced = 0;
     this.totalFoldersSynced = 0;
+    this.filesSyncStatus = 'IDLE';
+    this.foldersSyncStatus = 'IDLE';
+
     await this.db.files.connect();
     await this.db.folders.connect();
 


### PR DESCRIPTION
## What is Changed / Added
----
Restart sync status at the beginning of the startRemoteSync function.

## Why 
If a sync process failed and the user clicked the retry button, it would not work because it was starting with an error state instead of resetting to a clean state