### PR TITLE
feat: add gi.require_version calls for Nautilus and Gtk

### DIFF
--- a/assets/python-nautilus/internxt-virtual-drive.py
+++ b/assets/python-nautilus/internxt-virtual-drive.py
@@ -1,5 +1,8 @@
 import os
 
+import gi
+gi.require_version('Nautilus', '4.0')
+gi.require_version('Gtk', '4.0')
 
 from gi.repository import Nautilus, GObject, Gtk, Gdk
 import requests


### PR DESCRIPTION
## What is Changed / Added
----
- Pin Nautilus and Gtk version to 4.0

## Why
## Fix: Specify Nautilus 4.0 version requirement for extension compatibility

The Nautilus extension uses APIs specific to Nautilus/Gtk 4.0 for context menu items (make available offline/online) and file availability icons. Without explicit version specification, the extension could:

- Generate PyGIWarning messages in system logs
- Load incompatible API versions causing runtime errors
- Fail silently on systems with multiple Nautilus versions installed

This change explicitly requires Nautilus 4.0 and Gtk 4.0, ensuring consistent behavior and following PyGObject best practices. The extension will now fail fast with a clear error message on incompatible systems instead of loading with broken functionality.

**Compatibility**: Ubuntu 22.04+ / Debian 12+ (Ubuntu 20.04 LTS ended standard support in April 2025)
