### PR TITLE
feat: add RPM as an install method and include necessary build tools

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,9 @@ jobs:
           echo "@internxt:registry=https://npm.pkg.github.com/" > .npmrc
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
 
+      - name: Install rpm build tools
+        run: sudo apt-get install -y rpm
+
       - name: Install dependencies
         run: npm ci
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "linux": {
       "target": [
         "AppImage",
-        "deb"
+        "deb",
+        "rpm"
       ],
       "category": "Development"
     },
@@ -72,6 +73,14 @@
       "depends": [
         "libfuse2",
         "python3-nautilus"
+      ]
+    },
+    "rpm": {
+      "depends": [
+        "fuse-libs"
+      ],
+      "fpm": [
+        "--rpm-tag", "Recommends: nautilus-python"
       ]
     },
     "directories": {


### PR DESCRIPTION
## What is Changed / Added
----
RPM has been added as a new installation method. To support Red Hat-based distributions, a special configuration had to be added for the Nautilus dependency, as it is not available in these distributions, which prevented installation.
