### PR TITLE
fix: close database connection and drop database on user logout

### DIFF
--- a/src/apps/main/auth/handlers.ts
+++ b/src/apps/main/auth/handlers.ts
@@ -11,13 +11,12 @@ let isLoggedIn = false;
 function initializeLoginState() {
   const { newToken } = getCredentials();
   if (getUser() && newToken) {
-    setIsLoggedIn(true);
+    isLoggedIn = true;
   }
 }
 
 export function setIsLoggedIn(value: boolean) {
   isLoggedIn = value;
-
   getWidget()?.webContents.send('user-logged-in-changed', value);
 }
 

--- a/src/apps/main/database/data-source.test.ts
+++ b/src/apps/main/database/data-source.test.ts
@@ -1,0 +1,39 @@
+import { call, calls, partialSpyOn } from 'tests/vitest/utils.helper';
+import { AppDataSource, resetAppDataSourceOnLogout } from './data-source';
+
+describe('data-source', () => {
+  const dropDatabaseMock = partialSpyOn(AppDataSource, 'dropDatabase');
+  const destroyMock = partialSpyOn(AppDataSource, 'destroy');
+  const isInitializedMock = vi.spyOn(AppDataSource, 'isInitialized', 'get');
+
+  beforeEach(() => {
+    isInitializedMock.mockReturnValue(true);
+    dropDatabaseMock.mockResolvedValue(undefined);
+    destroyMock.mockResolvedValue(undefined);
+  });
+
+  it('should drop the database before destroying the connection on logout', async () => {
+    await resetAppDataSourceOnLogout();
+
+    calls(dropDatabaseMock).toHaveLength(1);
+    calls(destroyMock).toHaveLength(1);
+    expect(dropDatabaseMock.mock.invocationCallOrder[0]).toBeLessThan(destroyMock.mock.invocationCallOrder[0]);
+  });
+
+  it('should skip cleanup when the data source is not initialized', async () => {
+    isInitializedMock.mockReturnValue(false);
+
+    await resetAppDataSourceOnLogout();
+
+    calls(dropDatabaseMock).toHaveLength(0);
+    calls(destroyMock).toHaveLength(0);
+  });
+
+  it('should destroy the connection even when dropping the database fails', async () => {
+    dropDatabaseMock.mockRejectedValue(new Error('drop failed'));
+
+    await resetAppDataSourceOnLogout();
+
+    call(destroyMock).toStrictEqual([]);
+  });
+});

--- a/src/apps/main/database/data-source.ts
+++ b/src/apps/main/database/data-source.ts
@@ -1,4 +1,3 @@
-import eventBus from '../event-bus';
 import { DataSource } from 'typeorm';
 import { DriveFile } from './entities/DriveFile';
 import { DriveFolder } from './entities/DriveFolder';
@@ -16,8 +15,20 @@ export const AppDataSource = new DataSource({
 
 logger.debug({ msg: `Using database file at ${PATHS.DATABASE}` });
 
-eventBus.on('USER_LOGGED_OUT', () => {
-  AppDataSource.dropDatabase().catch((error) => {
+export async function resetAppDataSourceOnLogout() {
+  if (!AppDataSource.isInitialized) {
+    return;
+  }
+
+  try {
+    await AppDataSource.dropDatabase();
+  } catch (error) {
     logger.error({ msg: 'Error dropping database on user logout', error });
-  });
-});
+  }
+
+  try {
+    await AppDataSource.destroy();
+  } catch (error) {
+    logger.error({ msg: 'Error destroying database connection on user logout', error });
+  }
+}

--- a/src/apps/main/main.ts
+++ b/src/apps/main/main.ts
@@ -37,7 +37,7 @@ import './virtual-drive';
 
 import { app, ipcMain } from 'electron';
 import eventBus from './event-bus';
-import { AppDataSource } from './database/data-source';
+import { AppDataSource, resetAppDataSourceOnLogout } from './database/data-source';
 import { getIsLoggedIn } from './auth/handlers';
 import { getOrCreateWidged, getWidget, setBoundsOfWidgetByPath } from './windows/widget';
 import { createAuthWindow, getAuthWindow } from './windows/auth';
@@ -212,9 +212,7 @@ eventBus.on('USER_LOGGED_OUT', async () => {
   if (widget) {
     widget.destroy();
   }
-  if (AppDataSource.isInitialized) {
-    await AppDataSource.destroy();
-  }
+  await resetAppDataSourceOnLogout();
 
   // await uninstallNautilusExtension();
 });

--- a/src/infra/drive-server/client/drive-server.client.instance.test.ts
+++ b/src/infra/drive-server/client/drive-server.client.instance.test.ts
@@ -1,5 +1,6 @@
+import { closeUserSession } from '../../../apps/main/auth/handlers';
+import { getNewApiHeaders } from '../../../apps/main/auth/service';
 import { createClient } from '../drive-server.client';
-import { getNewApiHeaders, logout } from '../../../apps/main/auth/service';
 import { call } from 'tests/vitest/utils.helper';
 
 vi.mock('../drive-server.client', () => ({
@@ -8,7 +9,10 @@ vi.mock('../drive-server.client', () => ({
 
 vi.mock('../../../apps/main/auth/service', () => ({
   getNewApiHeaders: vi.fn(() => ({ Authorization: 'Bearer token' })),
-  logout: vi.fn(),
+}));
+
+vi.mock('../../../apps/main/auth/handlers', () => ({
+  closeUserSession: vi.fn(),
 }));
 
 describe('driveServerClient instance', () => {
@@ -29,6 +33,7 @@ describe('driveServerClient instance', () => {
 
   it('should call createClient with expected options', async () => {
     await import('./drive-server.client.instance');
+
     call(createClient).toMatchObject({
       baseUrl: expect.any(String),
       authHeadersProvider: expect.any(Function),
@@ -38,27 +43,25 @@ describe('driveServerClient instance', () => {
 
   it('should call getNewApiHeaders when authHeadersProvider is triggered', async () => {
     await import('./drive-server.client.instance');
-    const clientOptions = vi.mocked(createClient).mock.calls[0]![0]!;
+    const createClientCalls = vi.mocked(createClient).mock.calls;
+    const [{ authHeadersProvider }] = createClientCalls[0]!;
 
-    clientOptions.authHeadersProvider!();
+    authHeadersProvider!();
 
     expect(getNewApiHeaders).toHaveBeenCalled();
   });
 
-  it('should call logout when onUnauthorized is triggered', async () => {
+  it('should call closeUserSession when onUnauthorized is triggered', async () => {
     await import('./drive-server.client.instance');
-    const clientOptions = vi.mocked(createClient).mock.calls[0]![0]!;
+    const [{ onUnauthorized }] = vi.mocked(createClient).mock.calls[0]!;
 
-    clientOptions.onUnauthorized!();
+    onUnauthorized!();
 
-    expect(logout).toHaveBeenCalled();
+    expect(closeUserSession).toHaveBeenCalled();
   });
 
   it('should use process.env.NEW_DRIVE_URL as baseUrl', async () => {
     process.env.NEW_DRIVE_URL = 'https://mock.api';
-
-    vi.clearAllMocks();
-    vi.resetModules();
 
     await import('./drive-server.client.instance');
 

--- a/src/infra/drive-server/client/drive-server.client.instance.ts
+++ b/src/infra/drive-server/client/drive-server.client.instance.ts
@@ -1,12 +1,13 @@
 import { paths } from '../../schemas';
-import { getNewApiHeaders, logout } from '../../../apps/main/auth/service';
+import { getNewApiHeaders } from '../../../apps/main/auth/service';
+import { closeUserSession } from '../../../apps/main/auth/handlers';
 import { createClient } from '../drive-server.client';
 import { ClientOptions } from '../drive-server.types';
 
 const clientOptions: ClientOptions = {
   baseUrl: process.env.NEW_DRIVE_URL || '',
   authHeadersProvider: getNewApiHeaders,
-  onUnauthorized: logout,
+  onUnauthorized: closeUserSession,
 };
 
 export const driveServerClient = createClient<paths>(clientOptions);


### PR DESCRIPTION
## What is Changed / Added
----
The process of deleting the database and closing the connection upon logout was being handled improperly; there were two separate handlers for this purpose—one in the main method to close the connection and one in the data-source to drop the database. This created race conditions in which the database could close before the data was deleted, causing the widget to freeze and preventing users from logging in again.
