### PR TITLE
fix: [PB-6255] implement PendingFolderCreationTracker to manage folder creation dependencies

### DIFF
--- a/src/apps/drive/dependency-injection/virtual-drive/registerFolderServices.ts
+++ b/src/apps/drive/dependency-injection/virtual-drive/registerFolderServices.ts
@@ -2,6 +2,7 @@ import { ContainerBuilder } from 'diod';
 import { AllParentFoldersStatusIsExists } from '../../../../context/virtual-drive/folders/application/AllParentFoldersStatusIsExists';
 import { FolderCreator } from '../../../../context/virtual-drive/folders/application/create/FolderCreator';
 import { FolderCreatorFromOfflineFolder } from '../../../../context/virtual-drive/folders/application/create/FolderCreatorFromOfflineFolder';
+import { PendingFolderCreationTracker } from '../../../../context/virtual-drive/folders/application/create/PendingFolderCreationTracker';
 import { FolderDeleter } from '../../../../context/virtual-drive/folders/application/FolderDeleter';
 import { FolderMover } from '../../../../context/virtual-drive/folders/application/FolderMover';
 import { FolderPathUpdater } from '../../../../context/virtual-drive/folders/application/FolderPathUpdater';
@@ -55,6 +56,8 @@ export async function registerFolderServices(builder: ContainerBuilder): Promise
   builder.registerAndUse(AllParentFoldersStatusIsExists);
 
   builder.registerAndUse(FolderCreatorFromOfflineFolder);
+
+  builder.register(PendingFolderCreationTracker).use(PendingFolderCreationTracker).asSingleton().private();
 
   builder.registerAndUse(FolderCreator);
 

--- a/src/apps/drive/dependency-injection/virtual-drive/registerFolderServices.ts
+++ b/src/apps/drive/dependency-injection/virtual-drive/registerFolderServices.ts
@@ -2,7 +2,6 @@ import { ContainerBuilder } from 'diod';
 import { AllParentFoldersStatusIsExists } from '../../../../context/virtual-drive/folders/application/AllParentFoldersStatusIsExists';
 import { FolderCreator } from '../../../../context/virtual-drive/folders/application/create/FolderCreator';
 import { FolderCreatorFromOfflineFolder } from '../../../../context/virtual-drive/folders/application/create/FolderCreatorFromOfflineFolder';
-import { PendingFolderCreationTracker } from '../../../../context/virtual-drive/folders/application/create/PendingFolderCreationTracker';
 import { FolderDeleter } from '../../../../context/virtual-drive/folders/application/FolderDeleter';
 import { FolderMover } from '../../../../context/virtual-drive/folders/application/FolderMover';
 import { FolderPathUpdater } from '../../../../context/virtual-drive/folders/application/FolderPathUpdater';
@@ -56,8 +55,6 @@ export async function registerFolderServices(builder: ContainerBuilder): Promise
   builder.registerAndUse(AllParentFoldersStatusIsExists);
 
   builder.registerAndUse(FolderCreatorFromOfflineFolder);
-
-  builder.register(PendingFolderCreationTracker).use(PendingFolderCreationTracker).asSingleton().private();
 
   builder.registerAndUse(FolderCreator);
 

--- a/src/apps/drive/fuse/callbacks/TrashFolderCallback.test.ts
+++ b/src/apps/drive/fuse/callbacks/TrashFolderCallback.test.ts
@@ -1,0 +1,103 @@
+import { FolderDeleter } from '../../../../context/virtual-drive/folders/application/FolderDeleter';
+import { SingleFolderMatchingFinder } from '../../../../context/virtual-drive/folders/application/SingleFolderMatchingFinder';
+import { FolderMother } from '../../../../context/virtual-drive/folders/domain/__test-helpers__/FolderMother';
+import { FolderStatuses } from '../../../../context/virtual-drive/folders/domain/FolderStatus';
+import { SyncFolderMessenger } from '../../../../context/virtual-drive/folders/domain/SyncFolderMessenger';
+import { ContainerMock } from '../../__mocks__/ContainerMock';
+import { TrashFolderCallback } from './TrashFolderCallback';
+
+describe('TrashFolderCallback', () => {
+  it('returns success even when folder deletion exceeds callback timeout', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const container = new ContainerMock();
+      const folder = FolderMother.any();
+
+      const folderFinder = {
+        run: vi.fn(async () => {
+          return folder;
+        }),
+      } as unknown as SingleFolderMatchingFinder;
+
+      const folderDeleter = {
+        run: vi.fn(() => {
+          return new Promise<void>((resolve) => {
+            setTimeout(resolve, 5_000);
+          });
+        }),
+      } as unknown as FolderDeleter;
+
+      container.set(SingleFolderMatchingFinder, folderFinder);
+      container.set(FolderDeleter, folderDeleter);
+
+      const callback = new TrashFolderCallback(container as never);
+      const resultPromise = callback.execute('/Files/SlowFolder');
+
+      await vi.advanceTimersByTimeAsync(1_600);
+
+      const result = await resultPromise;
+
+      expect(result.isRight()).toBe(true);
+      expect(folderFinder.run).toHaveBeenCalledWith({
+        path: '/Files/SlowFolder',
+        status: FolderStatuses.EXISTS,
+      });
+      expect(folderDeleter.run).toHaveBeenCalledWith(folder.uuid);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reports issue when background deletion fails after timeout', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const container = new ContainerMock();
+      const folder = FolderMother.any();
+
+      const folderFinder = {
+        run: vi.fn(async () => {
+          return folder;
+        }),
+      } as unknown as SingleFolderMatchingFinder;
+
+      const folderDeleter = {
+        run: vi.fn(() => {
+          return new Promise<void>((_resolve, reject) => {
+            setTimeout(() => {
+              reject(new Error('slow-delete-failed'));
+            }, 5_000);
+          });
+        }),
+      } as unknown as FolderDeleter;
+
+      const syncFolderMessenger = {
+        issue: vi.fn(async () => undefined),
+      } as unknown as SyncFolderMessenger;
+
+      container.set(SingleFolderMatchingFinder, folderFinder);
+      container.set(FolderDeleter, folderDeleter);
+      container.set(SyncFolderMessenger, syncFolderMessenger);
+
+      const callback = new TrashFolderCallback(container as never);
+      const resultPromise = callback.execute('/Files/SlowFolder');
+
+      await vi.advanceTimersByTimeAsync(1_600);
+
+      const result = await resultPromise;
+      expect(result.isRight()).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(3_500);
+      await Promise.resolve();
+
+      expect(syncFolderMessenger.issue).toHaveBeenCalledWith({
+        error: 'FOLDER_TRASH_ERROR',
+        cause: 'UNKNOWN',
+        name: 'SlowFolder',
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/apps/drive/fuse/callbacks/TrashFolderCallback.ts
+++ b/src/apps/drive/fuse/callbacks/TrashFolderCallback.ts
@@ -1,10 +1,29 @@
 import { Container } from 'diod';
 import { basename } from 'path';
+import { logger } from '@internxt/drive-desktop-core/build/backend';
 import { FolderDeleter } from '../../../../context/virtual-drive/folders/application/FolderDeleter';
 import { SingleFolderMatchingFinder } from '../../../../context/virtual-drive/folders/application/SingleFolderMatchingFinder';
 import { FolderStatuses } from '../../../../context/virtual-drive/folders/domain/FolderStatus';
 import { SyncFolderMessenger } from '../../../../context/virtual-drive/folders/domain/SyncFolderMessenger';
 import { NotifyFuseCallback } from './FuseCallback';
+
+const FOLDER_TRASH_CALLBACK_TIMEOUT_MS = 1_500;
+
+type WaitWithTimeoutPops = {
+  promise: Promise<void>;
+  timeoutMs: number;
+};
+
+async function waitWithTimeout({ promise, timeoutMs }: WaitWithTimeoutPops) {
+  const completion = promise.then(() => true);
+  const timeout = new Promise<boolean>((resolve) => {
+    setTimeout(() => {
+      resolve(false);
+    }, timeoutMs);
+  });
+
+  return Promise.race([completion, timeout]);
+}
 
 export class TrashFolderCallback extends NotifyFuseCallback {
   constructor(private readonly container: Container) {
@@ -18,7 +37,33 @@ export class TrashFolderCallback extends NotifyFuseCallback {
         status: FolderStatuses.EXISTS,
       });
 
-      await this.container.get(FolderDeleter).run(folder.uuid);
+      const deletionPromise = this.container.get(FolderDeleter).run(folder.uuid);
+      const deletionCompletedInTime = await waitWithTimeout({
+        promise: deletionPromise,
+        timeoutMs: FOLDER_TRASH_CALLBACK_TIMEOUT_MS,
+      });
+
+      if (!deletionCompletedInTime) {
+        logger.warn({
+          msg: 'Folder deletion exceeded callback timeout. Continuing deletion in background.',
+          path,
+          timeoutMs: FOLDER_TRASH_CALLBACK_TIMEOUT_MS,
+        });
+
+        void deletionPromise.catch(async (error) => {
+          logger.error({
+            msg: 'Background folder deletion failed after callback timeout',
+            path,
+            error,
+          });
+
+          await this.container.get(SyncFolderMessenger).issue({
+            error: 'FOLDER_TRASH_ERROR',
+            cause: 'UNKNOWN',
+            name: basename(path),
+          });
+        });
+      }
 
       return this.right();
     } catch (throwed: unknown) {

--- a/src/context/virtual-drive/files/application/create/CreateFileOnTemporalFileUploaded.ts
+++ b/src/context/virtual-drive/files/application/create/CreateFileOnTemporalFileUploaded.ts
@@ -50,7 +50,7 @@ export class CreateFileOnTemporalFileUploaded implements DomainEventSubscriber<T
 
   async on(event: TemporalFileUploadedDomainEvent): Promise<void> {
     try {
-      this.create(event);
+      await this.create(event);
     } catch (err) {
       logger.error({
         msg: '[CreateFileOnOfflineFileUploaded] Error creating file:',

--- a/src/context/virtual-drive/files/application/create/FileCreator.test.ts
+++ b/src/context/virtual-drive/files/application/create/FileCreator.test.ts
@@ -10,7 +10,7 @@ import { FileMother } from '../../domain/__test-helpers__/FileMother';
 import { FileSizeMother } from '../../domain/__test-helpers__/FileSizeMother';
 import { right } from '../../../../shared/domain/Either';
 import { EventBusMock } from '../../../../../context/virtual-drive/shared/__mocks__/EventBusMock';
-import { PendingFolderCreationTracker } from '../../../folders/application/create/PendingFolderCreationTracker';
+import { clearPendingCreations } from '../../../folders/application/create/PendingFolderCreationTracker';
 
 describe('File Creator', () => {
   let remoteFileSystemMock: RemoteFileSystemMock;
@@ -26,16 +26,9 @@ describe('File Creator', () => {
     const parentFolderFinder = FolderFinderFactory.existingFolder();
     eventBus = new EventBusMock();
     notifier = new FileSyncNotifierMock();
-    const pendingFolderCreationTracker = new PendingFolderCreationTracker();
+    clearPendingCreations();
 
-    SUT = new FileCreator(
-      remoteFileSystemMock,
-      fileRepository,
-      parentFolderFinder,
-      eventBus,
-      notifier,
-      pendingFolderCreationTracker,
-    );
+    SUT = new FileCreator(remoteFileSystemMock, fileRepository, parentFolderFinder, eventBus, notifier);
   });
 
   it('creates the file on the drive server', async () => {

--- a/src/context/virtual-drive/files/application/create/FileCreator.test.ts
+++ b/src/context/virtual-drive/files/application/create/FileCreator.test.ts
@@ -10,6 +10,7 @@ import { FileMother } from '../../domain/__test-helpers__/FileMother';
 import { FileSizeMother } from '../../domain/__test-helpers__/FileSizeMother';
 import { right } from '../../../../shared/domain/Either';
 import { EventBusMock } from '../../../../../context/virtual-drive/shared/__mocks__/EventBusMock';
+import { PendingFolderCreationTracker } from '../../../folders/application/create/PendingFolderCreationTracker';
 
 describe('File Creator', () => {
   let remoteFileSystemMock: RemoteFileSystemMock;
@@ -25,8 +26,16 @@ describe('File Creator', () => {
     const parentFolderFinder = FolderFinderFactory.existingFolder();
     eventBus = new EventBusMock();
     notifier = new FileSyncNotifierMock();
+    const pendingFolderCreationTracker = new PendingFolderCreationTracker();
 
-    SUT = new FileCreator(remoteFileSystemMock, fileRepository, parentFolderFinder, eventBus, notifier);
+    SUT = new FileCreator(
+      remoteFileSystemMock,
+      fileRepository,
+      parentFolderFinder,
+      eventBus,
+      notifier,
+      pendingFolderCreationTracker,
+    );
   });
 
   it('creates the file on the drive server', async () => {

--- a/src/context/virtual-drive/files/application/create/FileCreator.ts
+++ b/src/context/virtual-drive/files/application/create/FileCreator.ts
@@ -12,7 +12,7 @@ import { SyncFileMessenger } from '../../domain/SyncFileMessenger';
 import { RemoteFileSystem } from '../../domain/file-systems/RemoteFileSystem';
 import { FileContentsId } from '../../domain/FileContentsId';
 import { FileFolderId } from '../../domain/FileFolderId';
-import { PendingFolderCreationTracker } from '../../../folders/application/create/PendingFolderCreationTracker';
+import { runAfterParentCreations } from '../../../folders/application/create/PendingFolderCreationTracker';
 
 @Service()
 export class FileCreator {
@@ -22,12 +22,11 @@ export class FileCreator {
     private readonly parentFolderFinder: ParentFolderFinder,
     private readonly eventBus: EventBus,
     private readonly notifier: SyncFileMessenger,
-    private readonly pendingFolderCreationTracker: PendingFolderCreationTracker,
   ) {}
 
   async run(path: string, contentsId: string, size: number): Promise<File> {
     try {
-      const file = await this.pendingFolderCreationTracker.runAfterParentCreations({
+      const file = await runAfterParentCreations({
         path,
         action: async () => {
           const fileSize = new FileSize(size);

--- a/src/context/virtual-drive/files/application/create/FileCreator.ts
+++ b/src/context/virtual-drive/files/application/create/FileCreator.ts
@@ -12,6 +12,7 @@ import { SyncFileMessenger } from '../../domain/SyncFileMessenger';
 import { RemoteFileSystem } from '../../domain/file-systems/RemoteFileSystem';
 import { FileContentsId } from '../../domain/FileContentsId';
 import { FileFolderId } from '../../domain/FileFolderId';
+import { PendingFolderCreationTracker } from '../../../folders/application/create/PendingFolderCreationTracker';
 
 @Service()
 export class FileCreator {
@@ -21,41 +22,47 @@ export class FileCreator {
     private readonly parentFolderFinder: ParentFolderFinder,
     private readonly eventBus: EventBus,
     private readonly notifier: SyncFileMessenger,
+    private readonly pendingFolderCreationTracker: PendingFolderCreationTracker,
   ) {}
 
   async run(path: string, contentsId: string, size: number): Promise<File> {
     try {
-      const fileSize = new FileSize(size);
-      const fileContentsId = new FileContentsId(contentsId);
-      const filePath = new FilePath(path);
+      const file = await this.pendingFolderCreationTracker.runAfterParentCreations({
+        path,
+        action: async () => {
+          const fileSize = new FileSize(size);
+          const fileContentsId = new FileContentsId(contentsId);
+          const filePath = new FilePath(path);
 
-      const folder = await this.parentFolderFinder.run(filePath);
-      const fileFolderId = new FileFolderId(folder.id);
+          const folder = await this.parentFolderFinder.run(filePath);
+          const fileFolderId = new FileFolderId(folder.id);
 
-      const either = await this.remote.persist({
-        contentsId: fileContentsId,
-        path: filePath,
-        size: fileSize,
-        folderId: fileFolderId,
-        folderUuid: folder.uuid,
-      });
+          const either = await this.remote.persist({
+            contentsId: fileContentsId,
+            path: filePath,
+            size: fileSize,
+            folderId: fileFolderId,
+            folderUuid: folder.uuid,
+          });
 
-      if (either.isLeft()) {
-        throw either.getLeft();
-      }
+          if (either.isLeft()) {
+            throw either.getLeft();
+          }
 
-      const { modificationTime, id, uuid, createdAt } = either.getRight();
+          const { modificationTime, id, uuid, createdAt } = either.getRight();
 
-      const file = File.create({
-        id,
-        uuid,
-        contentsId: fileContentsId.value,
-        folderId: fileFolderId.value,
-        createdAt,
-        modificationTime,
-        path: filePath.value,
-        size: fileSize.value,
-        updatedAt: modificationTime,
+          return File.create({
+            id,
+            uuid,
+            contentsId: fileContentsId.value,
+            folderId: fileFolderId.value,
+            createdAt,
+            modificationTime,
+            path: filePath.value,
+            size: fileSize.value,
+            updatedAt: modificationTime,
+          });
+        },
       });
 
       await this.repository.upsert(file);

--- a/src/context/virtual-drive/folders/__mocks__/FolderRemoteFileSystemMock.ts
+++ b/src/context/virtual-drive/folders/__mocks__/FolderRemoteFileSystemMock.ts
@@ -1,4 +1,4 @@
-import { Either, right } from '../../../shared/domain/Either';
+import { Either, left, right } from '../../../shared/domain/Either';
 import { Folder } from '../domain/Folder';
 import { FolderId } from '../domain/FolderId';
 import { FolderPath } from '../domain/FolderPath';
@@ -37,6 +37,15 @@ export class FolderRemoteFileSystemMock implements RemoteFileSystem {
         parentId: folder.parentId as number,
       } satisfies FolderPersistedDto),
     );
+  }
+
+  shouldFailPersistWith(plainName: string, parentFolderUuid: string, error: RemoteFileSystemErrors) {
+    this.persistMock(plainName, parentFolderUuid);
+    this.persistMock.mockResolvedValueOnce(left(error));
+  }
+
+  shouldFindFolder(folder?: Folder) {
+    this.searchWithMock.mockResolvedValueOnce(folder);
   }
 
   shouldTrash(folder: Folder, error?: Error) {

--- a/src/context/virtual-drive/folders/application/create/FolderCreator.test.ts
+++ b/src/context/virtual-drive/folders/application/create/FolderCreator.test.ts
@@ -9,7 +9,7 @@ import { FolderRemoteFileSystemMock } from '../../__mocks__/FolderRemoteFileSyst
 import { FolderRepositoryMock } from '../../__mocks__/FolderRepositoryMock';
 import { FolderPathMother } from '../../domain/__test-helpers__/FolderPathMother';
 import { FolderMother } from '../../domain/__test-helpers__/FolderMother';
-import { PendingFolderCreationTracker } from './PendingFolderCreationTracker';
+import { clearPendingCreations } from './PendingFolderCreationTracker';
 
 describe('Folder Creator', () => {
   let repository: FolderRepositoryMock;
@@ -22,11 +22,11 @@ describe('Folder Creator', () => {
     repository = new FolderRepositoryMock();
     remote = new FolderRemoteFileSystemMock();
     eventBus = new EventBusMock();
-    const pendingFolderCreationTracker = new PendingFolderCreationTracker();
+    clearPendingCreations();
 
     const parentFolderFinder = new ParentFolderFinder(repository);
 
-    SUT = new FolderCreator(repository, parentFolderFinder, remote, eventBus, pendingFolderCreationTracker);
+    SUT = new FolderCreator(repository, parentFolderFinder, remote, eventBus);
   });
 
   it('throws an InvalidArgument error if the path is not a valid posix path', async () => {

--- a/src/context/virtual-drive/folders/application/create/FolderCreator.test.ts
+++ b/src/context/virtual-drive/folders/application/create/FolderCreator.test.ts
@@ -9,6 +9,7 @@ import { FolderRemoteFileSystemMock } from '../../__mocks__/FolderRemoteFileSyst
 import { FolderRepositoryMock } from '../../__mocks__/FolderRepositoryMock';
 import { FolderPathMother } from '../../domain/__test-helpers__/FolderPathMother';
 import { FolderMother } from '../../domain/__test-helpers__/FolderMother';
+import { PendingFolderCreationTracker } from './PendingFolderCreationTracker';
 
 describe('Folder Creator', () => {
   let repository: FolderRepositoryMock;
@@ -21,10 +22,11 @@ describe('Folder Creator', () => {
     repository = new FolderRepositoryMock();
     remote = new FolderRemoteFileSystemMock();
     eventBus = new EventBusMock();
+    const pendingFolderCreationTracker = new PendingFolderCreationTracker();
 
     const parentFolderFinder = new ParentFolderFinder(repository);
 
-    SUT = new FolderCreator(repository, parentFolderFinder, remote, eventBus);
+    SUT = new FolderCreator(repository, parentFolderFinder, remote, eventBus, pendingFolderCreationTracker);
   });
 
   it('throws an InvalidArgument error if the path is not a valid posix path', async () => {
@@ -105,5 +107,34 @@ describe('Folder Creator', () => {
     expect(eventBus.publishMock).toBeCalledWith(
       expect.arrayContaining([expect.objectContaining({ aggregateId: createdFolder.uuid })]),
     );
+  });
+
+  it('throws when remote folder creation fails with non-recoverable error', async () => {
+    const path = FolderPathMother.any();
+    const parent = FolderMother.fromPartial({ path: path.dirname() });
+
+    remote.shouldFailPersistWith(path.name(), parent.uuid, 'UNHANDLED');
+    repository.matchingPartialMock.mockReturnValueOnce([]).mockReturnValueOnce([parent]).mockReturnValueOnce([parent]);
+
+    await expect(SUT.run(path.value)).rejects.toThrow(`Could not create folder ${path.value}: UNHANDLED`);
+  });
+
+  it('recovers from ALREADY_EXISTS by finding the folder remotely', async () => {
+    const path = FolderPathMother.any();
+    const parent = FolderMother.fromPartial({ path: path.dirname() });
+    const existingFolder = FolderMother.fromPartial({
+      path: path.value,
+      parentId: parent.id,
+    });
+
+    remote.shouldFailPersistWith(path.name(), parent.uuid, 'ALREADY_EXISTS');
+    remote.shouldFindFolder(existingFolder);
+
+    repository.matchingPartialMock.mockReturnValueOnce([]).mockReturnValueOnce([parent]).mockReturnValueOnce([parent]);
+
+    await SUT.run(path.value);
+
+    expect(repository.addMock).toBeCalledWith(expect.objectContaining({ uuid: existingFolder.uuid }));
+    expect(eventBus.publishMock).not.toBeCalled();
   });
 });

--- a/src/context/virtual-drive/folders/application/create/FolderCreator.ts
+++ b/src/context/virtual-drive/folders/application/create/FolderCreator.ts
@@ -12,6 +12,7 @@ import { FolderUuid } from '../../domain/FolderUuid';
 import { FolderInPathAlreadyExistsError } from '../../domain/errors/FolderInPathAlreadyExistsError';
 import { RemoteFileSystem } from '../../domain/file-systems/RemoteFileSystem';
 import { ParentFolderFinder } from '../ParentFolderFinder';
+import { PendingFolderCreationTracker } from './PendingFolderCreationTracker';
 
 @Service()
 export class FolderCreator {
@@ -20,6 +21,7 @@ export class FolderCreator {
     private readonly parentFolderFinder: ParentFolderFinder,
     private readonly remote: RemoteFileSystem,
     private readonly eventBus: EventBus,
+    private readonly pendingFolderCreationTracker: PendingFolderCreationTracker,
   ) {}
 
   private async ensureItDoesNotExists(path: FolderPath): Promise<void> {
@@ -39,36 +41,53 @@ export class FolderCreator {
   }
 
   async run(path: string): Promise<void> {
-    const folderPath = new FolderPath(path);
+    await this.pendingFolderCreationTracker.runTrackingCreation({
+      path,
+      action: async () => {
+        const folderPath = new FolderPath(path);
 
-    await this.ensureItDoesNotExists(folderPath);
-    const parent = await this.parentFolderFinder.run(folderPath);
-    const parentId = await this.findParentId(folderPath);
+        await this.ensureItDoesNotExists(folderPath);
+        const parent = await this.parentFolderFinder.run(folderPath);
+        const parentId = await this.findParentId(folderPath);
 
-    const response = await this.remote.persist(folderPath.name(), parent.uuid);
+        const response = await this.remote.persist(folderPath.name(), parent.uuid);
 
-    if (response.isLeft()) {
-      logger.error({
-        msg: 'Error creating folder:',
-        error: response.getLeft(),
-      });
-      return;
-    }
+        if (response.isLeft()) {
+          const error = response.getLeft();
 
-    const dto = response.getRight();
+          logger.error({
+            msg: 'Error creating folder:',
+            error,
+          });
 
-    const folder = Folder.create(
-      new FolderId(dto.id),
-      new FolderUuid(dto.uuid),
-      folderPath,
-      parentId,
-      FolderCreatedAt.fromString(dto.createdAt),
-      FolderUpdatedAt.fromString(dto.updatedAt),
-    );
+          if (error === 'ALREADY_EXISTS') {
+            const existingFolder = await this.remote.searchWith(parentId, folderPath);
 
-    await this.repository.add(folder);
+            if (existingFolder) {
+              await this.repository.add(existingFolder);
+              return;
+            }
+          }
 
-    const events = folder.pullDomainEvents();
-    this.eventBus.publish(events);
+          throw new Error(`Could not create folder ${folderPath.value}: ${error}`);
+        }
+
+        const dto = response.getRight();
+
+        const folder = Folder.create(
+          new FolderId(dto.id),
+          new FolderUuid(dto.uuid),
+          folderPath,
+          parentId,
+          FolderCreatedAt.fromString(dto.createdAt),
+          FolderUpdatedAt.fromString(dto.updatedAt),
+        );
+
+        await this.repository.add(folder);
+
+        const events = folder.pullDomainEvents();
+        this.eventBus.publish(events);
+      },
+    });
   }
 }

--- a/src/context/virtual-drive/folders/application/create/FolderCreator.ts
+++ b/src/context/virtual-drive/folders/application/create/FolderCreator.ts
@@ -12,7 +12,7 @@ import { FolderUuid } from '../../domain/FolderUuid';
 import { FolderInPathAlreadyExistsError } from '../../domain/errors/FolderInPathAlreadyExistsError';
 import { RemoteFileSystem } from '../../domain/file-systems/RemoteFileSystem';
 import { ParentFolderFinder } from '../ParentFolderFinder';
-import { PendingFolderCreationTracker } from './PendingFolderCreationTracker';
+import { runTrackingCreation } from './PendingFolderCreationTracker';
 
 @Service()
 export class FolderCreator {
@@ -21,7 +21,6 @@ export class FolderCreator {
     private readonly parentFolderFinder: ParentFolderFinder,
     private readonly remote: RemoteFileSystem,
     private readonly eventBus: EventBus,
-    private readonly pendingFolderCreationTracker: PendingFolderCreationTracker,
   ) {}
 
   private async ensureItDoesNotExists(path: FolderPath): Promise<void> {
@@ -41,7 +40,7 @@ export class FolderCreator {
   }
 
   async run(path: string): Promise<void> {
-    await this.pendingFolderCreationTracker.runTrackingCreation({
+    await runTrackingCreation({
       path,
       action: async () => {
         const folderPath = new FolderPath(path);

--- a/src/context/virtual-drive/folders/application/create/PendingFolderCreationTracker.test.ts
+++ b/src/context/virtual-drive/folders/application/create/PendingFolderCreationTracker.test.ts
@@ -1,0 +1,41 @@
+import { PendingFolderCreationTracker } from './PendingFolderCreationTracker';
+
+describe('PendingFolderCreationTracker', () => {
+  it('waits for a parent folder creation before running child action', async () => {
+    const tracker = new PendingFolderCreationTracker();
+
+    let resolveParentCreation: (() => void) | undefined;
+    const events: string[] = [];
+
+    const parentPromise = tracker.runTrackingCreation({
+      path: '/Documents',
+      action: async () => {
+        events.push('parent-started');
+
+        await new Promise<void>((resolve) => {
+          resolveParentCreation = resolve;
+        });
+
+        events.push('parent-finished');
+      },
+    });
+
+    const childPromise = tracker.runAfterParentCreations({
+      path: '/Documents/Taxes/file.txt',
+      action: async () => {
+        events.push('child-started');
+      },
+    });
+
+    await Promise.resolve();
+
+    expect(events).toStrictEqual(['parent-started']);
+
+    resolveParentCreation?.();
+
+    await parentPromise;
+    await childPromise;
+
+    expect(events).toStrictEqual(['parent-started', 'parent-finished', 'child-started']);
+  });
+});

--- a/src/context/virtual-drive/folders/application/create/PendingFolderCreationTracker.test.ts
+++ b/src/context/virtual-drive/folders/application/create/PendingFolderCreationTracker.test.ts
@@ -1,13 +1,15 @@
-import { PendingFolderCreationTracker } from './PendingFolderCreationTracker';
+import { clearPendingCreations, runAfterParentCreations, runTrackingCreation } from './PendingFolderCreationTracker';
 
 describe('PendingFolderCreationTracker', () => {
-  it('waits for a parent folder creation before running child action', async () => {
-    const tracker = new PendingFolderCreationTracker();
+  beforeEach(() => {
+    clearPendingCreations();
+  });
 
+  it('waits for a parent folder creation before running child action', async () => {
     let resolveParentCreation: (() => void) | undefined;
     const events: string[] = [];
 
-    const parentPromise = tracker.runTrackingCreation({
+    const parentPromise = runTrackingCreation({
       path: '/Documents',
       action: async () => {
         events.push('parent-started');
@@ -20,7 +22,7 @@ describe('PendingFolderCreationTracker', () => {
       },
     });
 
-    const childPromise = tracker.runAfterParentCreations({
+    const childPromise = runAfterParentCreations({
       path: '/Documents/Taxes/file.txt',
       action: async () => {
         events.push('child-started');

--- a/src/context/virtual-drive/folders/application/create/PendingFolderCreationTracker.ts
+++ b/src/context/virtual-drive/folders/application/create/PendingFolderCreationTracker.ts
@@ -1,10 +1,11 @@
 import { posix } from 'node:path';
-import { Service } from 'diod';
 
-type RunAfterParentCreationsPops<T> = {
+type ActionProps<T> = {
   path: string;
   action: () => Promise<T>;
 };
+
+const pendingFolderCreationByPath = new Map<string, Promise<void>>();
 
 function normalizePath(path: string): string {
   const normalizedPath = posix.normalize(path);
@@ -30,52 +31,51 @@ function getParentPaths(path: string): string[] {
   return parentPaths;
 }
 
-@Service()
-export class PendingFolderCreationTracker {
-  private readonly pendingFolderCreationByPath = new Map<string, Promise<void>>();
+function getPendingParentCreations(path: string): Promise<void>[] {
+  const parentPaths = getParentPaths(path);
 
-  async runAfterParentCreations<T>({ path, action }: RunAfterParentCreationsPops<T>): Promise<T> {
-    const pendingParentCreations = this.getPendingParentCreations(path);
+  return parentPaths
+    .map((parentPath) => pendingFolderCreationByPath.get(parentPath))
+    .filter((pending): pending is Promise<void> => Boolean(pending));
+}
 
-    if (pendingParentCreations.length > 0) {
-      await Promise.all(pendingParentCreations);
+function track<T>(path: string, creationPromise: Promise<T>): void {
+  const normalizedPath = normalizePath(path);
+
+  const pendingPromise = creationPromise.then(() => undefined).catch(() => undefined);
+
+  pendingFolderCreationByPath.set(normalizedPath, pendingPromise);
+
+  void pendingPromise.finally(() => {
+    if (pendingFolderCreationByPath.get(normalizedPath) === pendingPromise) {
+      pendingFolderCreationByPath.delete(normalizedPath);
     }
+  });
+}
 
-    return action();
+export async function runAfterParentCreations<T>({ path, action }: ActionProps<T>): Promise<T> {
+  const pendingParentCreations = getPendingParentCreations(path);
+
+  if (pendingParentCreations.length > 0) {
+    await Promise.all(pendingParentCreations);
   }
 
-  async runTrackingCreation<T>({ path, action }: RunAfterParentCreationsPops<T>): Promise<T> {
-    const pendingParentCreations = this.getPendingParentCreations(path);
+  return action();
+}
 
-    if (pendingParentCreations.length > 0) {
-      await Promise.all(pendingParentCreations);
-    }
+export async function runTrackingCreation<T>({ path, action }: ActionProps<T>): Promise<T> {
+  const pendingParentCreations = getPendingParentCreations(path);
 
-    const creationPromise = action();
-    this.track(path, creationPromise);
-
-    return creationPromise;
+  if (pendingParentCreations.length > 0) {
+    await Promise.all(pendingParentCreations);
   }
 
-  private track<T>(path: string, creationPromise: Promise<T>): void {
-    const normalizedPath = normalizePath(path);
+  const creationPromise = action();
+  track(path, creationPromise);
 
-    const pendingPromise = creationPromise.then(() => undefined).catch(() => undefined);
+  return creationPromise;
+}
 
-    this.pendingFolderCreationByPath.set(normalizedPath, pendingPromise);
-
-    void pendingPromise.finally(() => {
-      if (this.pendingFolderCreationByPath.get(normalizedPath) === pendingPromise) {
-        this.pendingFolderCreationByPath.delete(normalizedPath);
-      }
-    });
-  }
-
-  private getPendingParentCreations(path: string): Promise<void>[] {
-    const parentPaths = getParentPaths(path);
-
-    return parentPaths
-      .map((parentPath) => this.pendingFolderCreationByPath.get(parentPath))
-      .filter((pending): pending is Promise<void> => Boolean(pending));
-  }
+export function clearPendingCreations(): void {
+  pendingFolderCreationByPath.clear();
 }

--- a/src/context/virtual-drive/folders/application/create/PendingFolderCreationTracker.ts
+++ b/src/context/virtual-drive/folders/application/create/PendingFolderCreationTracker.ts
@@ -1,0 +1,81 @@
+import { posix } from 'node:path';
+import { Service } from 'diod';
+
+type RunAfterParentCreationsPops<T> = {
+  path: string;
+  action: () => Promise<T>;
+};
+
+function normalizePath(path: string): string {
+  const normalizedPath = posix.normalize(path);
+
+  if (normalizedPath.length > 1 && normalizedPath.endsWith('/')) {
+    return normalizedPath.slice(0, -1);
+  }
+
+  return normalizedPath;
+}
+
+function getParentPaths(path: string): string[] {
+  const normalizedPath = normalizePath(path);
+  const parentPaths: string[] = [];
+
+  let currentPath = posix.dirname(normalizedPath);
+
+  while (currentPath !== '.' && currentPath !== '/') {
+    parentPaths.unshift(currentPath);
+    currentPath = posix.dirname(currentPath);
+  }
+
+  return parentPaths;
+}
+
+@Service()
+export class PendingFolderCreationTracker {
+  private readonly pendingFolderCreationByPath = new Map<string, Promise<void>>();
+
+  async runAfterParentCreations<T>({ path, action }: RunAfterParentCreationsPops<T>): Promise<T> {
+    const pendingParentCreations = this.getPendingParentCreations(path);
+
+    if (pendingParentCreations.length > 0) {
+      await Promise.all(pendingParentCreations);
+    }
+
+    return action();
+  }
+
+  async runTrackingCreation<T>({ path, action }: RunAfterParentCreationsPops<T>): Promise<T> {
+    const pendingParentCreations = this.getPendingParentCreations(path);
+
+    if (pendingParentCreations.length > 0) {
+      await Promise.all(pendingParentCreations);
+    }
+
+    const creationPromise = action();
+    this.track(path, creationPromise);
+
+    return creationPromise;
+  }
+
+  private track<T>(path: string, creationPromise: Promise<T>): void {
+    const normalizedPath = normalizePath(path);
+
+    const pendingPromise = creationPromise.then(() => undefined).catch(() => undefined);
+
+    this.pendingFolderCreationByPath.set(normalizedPath, pendingPromise);
+
+    void pendingPromise.finally(() => {
+      if (this.pendingFolderCreationByPath.get(normalizedPath) === pendingPromise) {
+        this.pendingFolderCreationByPath.delete(normalizedPath);
+      }
+    });
+  }
+
+  private getPendingParentCreations(path: string): Promise<void>[] {
+    const parentPaths = getParentPaths(path);
+
+    return parentPaths
+      .map((parentPath) => this.pendingFolderCreationByPath.get(parentPath))
+      .filter((pending): pending is Promise<void> => Boolean(pending));
+  }
+}


### PR DESCRIPTION
## What is Changed / Added
----
### Problem

When users copy multiple top-level folders (commonly 2-3) with deep nested trees from the host system into the drive mount, creation events are processed concurrently rather than strictly top-down.

Under this load pattern, descendant operations (child folders/files) may run before their ancestor folders are fully created and visible. This leads to intermittent errors such as:

- parent folder not found
- no such file or directory

This issue is more likely to appear in bulk copy operations that include several complex trees at once.

### Example: Multi-Folder Copy With Complex Trees

```text
Host (source) -> Drive (destination)

Drive/
├── Team-A/
│   ├── 2026/
│   │   ├── Q1/
│   │   │   ├── budget.xlsx
│   │   │   └── notes/
│   │   │       └── summary.md
│   │   └── Q2/
│   │       └── forecast.csv
│   └── assets/
│       ├── logos/
│       │   └── logo-final.svg
│       └── media/
│           └── intro.mp4
├── Team-B/
│   ├── clients/
│   │   ├── acme/
│   │   │   ├── contract.pdf
│   │   │   └── drafts/
│   │   │       └── v3.docx
│   │   └── globex/
│   │       └── proposal.pptx
│   └── legal/
│       └── nda-template.docx
└── Team-C/
    ├── engineering/
    │   ├── backend/
    │   │   └── api-spec.yaml
    │   └── frontend/
    │       └── ui-kit.fig
    └── ops/
        └── runbooks/
            └── incident-001.md
```

### Typical Failing Concurrent Order

```text
t0: create /Team-A/2026/Q1/notes            (starts)
t1: create /Team-A                           (starts later)
t2: create /Team-B/clients/acme/drafts      (starts)
t3: create /Team-B/clients                  (starts later)
t4: create file /Team-A/2026/Q1/notes/summary.md
t5: create file /Team-B/clients/acme/drafts/v3.docx

Potential failure:
- summary.md resolves before /Team-A and /Team-A/2026/Q1 are fully available
- v3.docx resolves before /Team-B/clients/acme is fully available
```

### Root Cause

The bug is a race condition in dependent creation operations:

- Parent and child paths can execute in parallel during bulk copy.
- Descendant operations are not guaranteed to wait for ancestor completion.
- Parent resolution can therefore run against an incomplete hierarchy.

This is not a path-validation problem; it is an ordering/synchronization problem.

### Solution

Implemented a synchronization layer for in-flight folder creation dependencies.

The flow now tracks pending folder-creation promises by normalized path and makes descendant operations wait for required parents before continuing.

#### New behavior

1. Folder creation starts for path `P`.
2. Path `P` is registered in an in-memory pending registry.
3. A new folder/file operation for descendant `D` computes all parent paths of `D`.
4. If any parent path is still pending, `D` waits for those parent promises.
5. Once parent creation settles, the pending entry is removed automatically.
6. Descendant operation proceeds with a valid hierarchy.

### Conceptual Flow

```text
create /Team-A
  -> register /Team-A as pending

create /Team-A/2026
  -> sees /Team-A pending
  -> waits
  -> creates /Team-A/2026
  -> register /Team-A/2026 as pending

create /Team-A/2026/Q1/notes/summary.md
  -> sees /Team-A/2026 (and potentially deeper parent) pending
  -> waits for required parents
  -> continues file creation
```