### PR TITLE
feat: Get Attributes operation + Electron 21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
         "@types/async": "^3.2.16",
         "@types/bytes": "^3.1.1",
         "@types/chance": "^1.1.3",
-        "@types/crypto-js": "^4.2.0",
         "@types/dotenv-webpack": "^7.0.3",
         "@types/jsonwebtoken": "^9.0.2",
         "@types/lodash": "^4.14.178",
@@ -69,14 +68,13 @@
         "concurrently": "^6.5.1",
         "core-js": "^3.20.1",
         "cross-env": "^7.0.3",
-        "crypto-js": "4.2.0",
         "css-loader": "^6.5.1",
         "css-minimizer-webpack-plugin": "^3.3.1",
         "dayjs": "^1.10.7",
         "detect-port": "^1.3.0",
         "dotenv": "^10.0.0",
         "dotenv-webpack": "^7.0.3",
-        "electron": "^19.1.9",
+        "electron": "^21.4.4",
         "electron-builder": "^23.6.0",
         "electron-debug": "^3.2.0",
         "electron-fetch": "^1.9.1",
@@ -6235,13 +6233,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/crypto-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.2.tgz",
-      "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -6689,6 +6680,17 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.21.0",
@@ -9508,22 +9510,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
-      "engines": [
-        "node >= 0.8"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
     "node_modules/concurrently": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-6.5.1.tgz",
@@ -9831,13 +9817,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/crypto-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/css-declaration-sorter": {
       "version": "6.4.1",
@@ -11047,22 +11026,22 @@
       }
     },
     "node_modules/electron": {
-      "version": "19.1.9",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-19.1.9.tgz",
-      "integrity": "sha512-XT5LkTzIHB+ZtD3dTmNnKjVBWrDWReCKt9G1uAFLz6uJMEVcIUiYO+fph5pLXETiBw/QZBx8egduMEfIccLx+g==",
+      "version": "21.4.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-21.4.4.tgz",
+      "integrity": "sha512-N5O7y7Gtt7mDgkJLkW49ETiT8M3myZ9tNIEvGTKhpBduX4WdgMj6c3hYeYBD6XW7SvbRkWEQaTl25RNday8Xpw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron/get": "^1.14.1",
         "@types/node": "^16.11.26",
-        "extract-zip": "^1.0.3"
+        "extract-zip": "^2.0.1"
       },
       "bin": {
         "electron": "cli.js"
       },
       "engines": {
-        "node": ">= 8.6"
+        "node": ">= 10.17.0"
       }
     },
     "node_modules/electron-builder": {
@@ -12885,37 +12864,41 @@
       "license": "MIT"
     },
     "node_modules/extract-zip": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
-      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "concat-stream": "^1.6.2",
-        "debug": "^2.6.9",
-        "mkdirp": "^0.5.4",
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
       },
       "bin": {
         "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
       }
     },
-    "node_modules/extract-zip/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/extract-zip/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/extsprintf": {
       "version": "1.4.1",
@@ -16680,19 +16663,6 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
@@ -22577,13 +22547,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/typeorm": {
       "version": "0.3.28",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "detect-port": "^1.3.0",
     "dotenv": "^10.0.0",
     "dotenv-webpack": "^7.0.3",
-    "electron": "^19.1.9",
+    "electron": "^21.4.4",
     "electron-builder": "^23.6.0",
     "electron-debug": "^3.2.0",
     "electron-fetch": "^1.9.1",

--- a/packages/fuse-daemon/internal/client/client.go
+++ b/packages/fuse-daemon/internal/client/client.go
@@ -1,8 +1,11 @@
 package client
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -54,4 +57,37 @@ func (client *Client) NotifyReady(logger *slog.Logger) error {
 
 	logger.Info("notified electron of readiness")
 	return nil
+}
+
+ func (client *Client) Post(context context.Context, path OperationPath, in any, out any) error {
+  body, err := json.Marshal(in)
+  if err != nil {
+    return fmt.Errorf("failed to marshal request: %w", err)
+  }
+  url := serverURL + string(path)
+  req, err := http.NewRequestWithContext(context, http.MethodPost, url, bytes.NewBuffer(body))
+  if err != nil {
+		return fmt.Errorf("Error creating Post request: %w", err)
+	}
+
+  req.Header.Set("Content-Type", "application/json")
+
+  resp, err := client.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("sending Post request: %w", err)
+	}
+  defer resp.Body.Close()
+
+  if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status from Post endpoint: %d", resp.StatusCode)
+	}
+  resBody, err := io.ReadAll(resp.Body)
+  if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+  err = json.Unmarshal(resBody, out)
+  if err != nil {
+		return fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+  return nil
 }

--- a/packages/fuse-daemon/internal/client/operation_paths.go
+++ b/packages/fuse-daemon/internal/client/operation_paths.go
@@ -1,0 +1,7 @@
+package client
+type OperationPath string
+const(
+  OperationGetAttr OperationPath = "/op/getattributes"
+)
+
+const serverURL = "http://localhost"

--- a/packages/fuse-daemon/internal/filesystem/mount.go
+++ b/packages/fuse-daemon/internal/filesystem/mount.go
@@ -2,11 +2,13 @@ package filesystem
 
 import (
 	"log/slog"
+	"syscall"
+
+	"internxt/drive-desktop-linux/fuse-daemon/internal/client"
 
 	"github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
 	"github.com/hanwen/go-fuse/v2/fuse/pathfs"
-	"internxt/drive-desktop-linux/fuse-daemon/internal/client"
 )
 
 // Mount attaches InternxtFilesystem to mountPoint and starts serving FUSE operations.
@@ -22,7 +24,10 @@ func Mount(mountPoint string, logger *slog.Logger, client *client.Client) (*fuse
 		MaxReadAhead:  128 * 1024,
 		DisableXAttrs: false,
 		Debug:         false,
+    DirectMount: true,
 	}
+
+	_ = syscall.Unmount(mountPoint, 0)
 
 	server, _, err := nodefs.Mount(mountPoint, nodeFileSystem.Root(), mountOptions, nil)
 	if err != nil {

--- a/packages/fuse-daemon/internal/filesystem/operations.go
+++ b/packages/fuse-daemon/internal/filesystem/operations.go
@@ -3,10 +3,11 @@ package filesystem
 import (
 	"log/slog"
 
+	"internxt/drive-desktop-linux/fuse-daemon/internal/client"
+
 	"github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/hanwen/go-fuse/v2/fuse/nodefs"
 	"github.com/hanwen/go-fuse/v2/fuse/pathfs"
-	"internxt/drive-desktop-linux/fuse-daemon/internal/client"
 )
 
 // InternxtFilesystem is the FUSE filesystem implementation.
@@ -31,8 +32,28 @@ func NewInternxtFilesystem(logger *slog.Logger, client *client.Client) *Internxt
 	}
 }
 func (fs *InternxtFilesystem) GetAttr(name string, context *fuse.Context) (*fuse.Attr, fuse.Status) {
-	fs.logger.Warn("not implemented", "op", "GetAttr", "path", name)
-	return nil, fuse.ENOSYS
+  fs.logger.Debug("Recieved GetAttr call: ", "name", name)
+  body := struct { Path string `json:"path"` }{ Path: name }
+  response := GetAttributesCallbackData{}
+  err := fs.client.Post(context,client.OperationGetAttr, body, &response)
+  if err != nil {
+    fs.logger.Error("Error occurred while fetching attributes", "error", err)
+    return nil, fuse.EIO
+  }
+  var atime uint64
+  if response.Atime != nil {
+      atime = uint64(response.Atime.Unix())
+  }
+	attr := &fuse.Attr{
+    Mode:  response.Mode,
+    Size:  response.Size,
+    Mtime: uint64(response.Mtime.Unix()),
+    Ctime: uint64(response.Ctime.Unix()),
+    Atime: atime,
+    Owner: fuse.Owner{Uid: response.Uid, Gid: response.Gid},
+    Nlink: response.Nlink,
+  }
+  return attr, fuse.OK
 }
 
 func (fs *InternxtFilesystem) OpenDir(name string, context *fuse.Context) ([]fuse.DirEntry, fuse.Status) {

--- a/packages/fuse-daemon/internal/filesystem/responses.go
+++ b/packages/fuse-daemon/internal/filesystem/responses.go
@@ -1,0 +1,14 @@
+package filesystem
+
+import "time"
+
+type GetAttributesCallbackData struct {
+	Mode  uint32 `json:"mode"`
+	Size  uint64  `json:"size"`
+	Mtime time.Time `json:"mtime"`
+	Ctime time.Time `json:"ctime"`
+	Atime *time.Time `json:"atime,omitempty"`
+	Uid   uint32 `json:"uid"`
+	Gid   uint32 `json:"gid"`
+	Nlink uint32 `json:"nlink"`
+}

--- a/src/apps/drive/fuse/callbacks/FuseCodes.ts
+++ b/src/apps/drive/fuse/callbacks/FuseCodes.ts
@@ -1,25 +1,24 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-import Fuse from '@gcas/fuse';
-
-export enum FuseCodes {
+export const FuseCodes = {
   // Operation not supported (Functionality not implemented)
-  ENOSYS = Fuse.ENOSYS,
+  ENOSYS: 38,
 
   // No such file or directory
-  ENOENT = Fuse.ENOENT,
+  ENOENT: 2,
 
   // File or directory already exists
-  EEXIST = Fuse.EEXIST,
+  EEXIST: 17,
 
   // Input/output error
-  EIO = Fuse.EIO,
+  EIO: 5,
 
   // Invalid argument
-  EINVAL = Fuse.EINVAL,
+  EINVAL: 22,
 
   // Permission denied
-  EACCES = Fuse.EACCES,
+  EACCES: 13,
 
   // Network is down
-  ENETDOWN = Fuse.ENETDOWN,
-}
+  ENETDOWN: 100,
+} as const;
+
+export type FuseCode = (typeof FuseCodes)[keyof typeof FuseCodes];

--- a/src/apps/drive/fuse/callbacks/FuseErrors.ts
+++ b/src/apps/drive/fuse/callbacks/FuseErrors.ts
@@ -1,10 +1,10 @@
-import { FuseCodes } from './FuseCodes';
+import { FuseCode, FuseCodes } from './FuseCodes';
 
 export class FuseError extends Error {
   public readonly code: number;
   public readonly timestamp: Date;
 
-  constructor(code: FuseCodes, message: string) {
+  constructor(code: FuseCode, message: string) {
     super(message);
     this.code = code;
     this.timestamp = new Date();

--- a/src/apps/drive/index.ts
+++ b/src/apps/drive/index.ts
@@ -2,7 +2,7 @@ import { getRootVirtualDrive } from '../main/virtual-root-folder/service';
 import { broadcastToWindows } from '../main/windows';
 // import { DependencyInjectionUserProvider } from '../shared/dependency-injection/DependencyInjectionUserProvider';
 // import { VirtualDrive } from './virtual-drive/VirtualDrive';
-// import { DriveDependencyContainerFactory } from './dependency-injection/DriveDependencyContainerFactory';
+import { DriveDependencyContainerFactory } from './dependency-injection/DriveDependencyContainerFactory';
 // import { FuseApp } from './fuse/FuseApp';
 // import { HydrationApi } from './hydration-api/HydrationApi';
 import { logger } from '@internxt/drive-desktop-core/build/backend';
@@ -15,7 +15,7 @@ import { startDaemon, stopDaemon } from '../../backend/features/fuse-daemon/daem
 export async function startVirtualDrive() {
   const localRoot = getRootVirtualDrive();
 
-  // const container = await DriveDependencyContainerFactory.build();
+  const container = await DriveDependencyContainerFactory.build();
   // const user = DependencyInjectionUserProvider.get();
   // const virtualDrive = new VirtualDrive(container);
   // hydrationApi = new HydrationApi(container);
@@ -25,7 +25,7 @@ export async function startVirtualDrive() {
   // await hydrationApi.start({ debug: false, timeElapsed: false });
   // await fuseApp.start();
 
-  await startFuseDaemonServer();
+  await startFuseDaemonServer(container);
   await startDaemon(localRoot);
 
   broadcastToWindows('virtual-drive-status-change', 'MOUNTED');

--- a/src/backend/features/fuse-daemon/constants.ts
+++ b/src/backend/features/fuse-daemon/constants.ts
@@ -1,0 +1,26 @@
+/**
+ * property to define a regular file when requesting in the get attributes fuse request.
+ * encodes both file type and permissions
+ */
+export const FILE_MODE = 33188;
+/**
+ * property to define a folder when requesting in the get attributes fuse request.
+ * encodes both file type and permissions
+ */
+export const FOLDER_MODE = 16877;
+
+export type GetAttributesCallbackData = {
+  mode: number;
+  size: number;
+  mtime: Date;
+  ctime: Date;
+  atime?: Date;
+  uid: number;
+  gid: number;
+  /** this property tells the kernel the number of hard links
+   * for directories this is at least 2
+   * when nlink reaches 0 and no process has the file open, the kernel interprets
+   * its a deleted file/folder
+   * */
+  nlink: number;
+};

--- a/src/backend/features/fuse-daemon/controllers/operations.controller.ts
+++ b/src/backend/features/fuse-daemon/controllers/operations.controller.ts
@@ -1,2 +1,17 @@
-// Controllers for FUSE operation endpoints (POST /op/<name>).
-// Each operation will get its own handler here as it is implemented in PB-6161.
+import { Request, Response } from 'express';
+import { logger } from '@internxt/drive-desktop-core/build/backend';
+import { getAttributes } from '../services/operations.service';
+import { Container } from 'diod';
+
+export async function getAttributesController(req: Request, res: Response, container: Container) {
+  logger.debug({ msg: '[FUSE DAEMON] GetAttributes signal received' });
+  const rawPath: string = req.body.path ?? '';
+  const normalizedPath = rawPath === '' || rawPath.startsWith('/') ? rawPath : `/${rawPath}`;
+  const responseGetattr = await getAttributes(normalizedPath, container);
+  if (responseGetattr.error) {
+    logger.error({ msg: responseGetattr.error.message });
+    res.status(404).send();
+  } else {
+    res.json(responseGetattr.data);
+  }
+}

--- a/src/backend/features/fuse-daemon/routes/operations.routes.ts
+++ b/src/backend/features/fuse-daemon/routes/operations.routes.ts
@@ -1,9 +1,11 @@
 import { Router } from 'express';
+import { getAttributesController } from '../controllers/operations.controller';
+import { Container } from 'diod';
 
 // Routes for FUSE operation endpoints (POST /op/<name>).
 // Each operation will be registered here as it is implemented in PB-6161.
-export function buildOperationsRouter(): Router {
+export function buildOperationsRouter(container: Container): Router {
   const router = Router();
-
+  router.post('/getattributes', (req, res) => getAttributesController(req, res, container));
   return router;
 }

--- a/src/backend/features/fuse-daemon/server.ts
+++ b/src/backend/features/fuse-daemon/server.ts
@@ -1,6 +1,6 @@
 import { rmSync } from 'node:fs';
 import express from 'express';
-import { Server } from 'http';
+import { Server } from 'node:http';
 import { Container } from 'diod';
 import { logger } from '@internxt/drive-desktop-core/build/backend';
 import { PATHS } from '../../../core/electron/paths';

--- a/src/backend/features/fuse-daemon/server.ts
+++ b/src/backend/features/fuse-daemon/server.ts
@@ -1,6 +1,7 @@
 import { rmSync } from 'node:fs';
 import express from 'express';
-import { Server } from 'node:http';
+import { Server } from 'http';
+import { Container } from 'diod';
 import { logger } from '@internxt/drive-desktop-core/build/backend';
 import { PATHS } from '../../../core/electron/paths';
 import { buildDaemonRouter } from './routes/daemon.routes';
@@ -8,13 +9,13 @@ import { buildOperationsRouter } from './routes/operations.routes';
 
 let server: Server | null = null;
 
-export function startFuseDaemonServer(): Promise<void> {
+export function startFuseDaemonServer(container: Container): Promise<void> {
   return new Promise((resolve) => {
     const app = express();
     app.use(express.json());
 
     app.use('/daemon', buildDaemonRouter());
-    app.use('/op', buildOperationsRouter());
+    app.use('/op', buildOperationsRouter(container));
 
     rmSync(PATHS.FUSE_DAEMON_SOCKET, { force: true });
 

--- a/src/backend/features/fuse-daemon/services/operations.service.ts
+++ b/src/backend/features/fuse-daemon/services/operations.service.ts
@@ -1,0 +1,85 @@
+import { Container } from 'diod';
+import { FILE_MODE, FOLDER_MODE, GetAttributesCallbackData } from '../constants';
+import { FirstsFileSearcher } from '../../../../context/virtual-drive/files/application/search/FirstsFileSearcher';
+import { FileStatuses } from '../../../../context/virtual-drive/files/domain/FileStatus';
+import { SingleFolderMatchingSearcher } from '../../../../context/virtual-drive/folders/application/SingleFolderMatchingSearcher';
+import { TemporalFileByPathFinder } from '../../../../context/storage/TemporalFiles/application/find/TemporalFileByPathFinder';
+import { FuseCodes } from '../../../../apps/drive/fuse/callbacks/FuseCodes';
+import { logger } from '@internxt/drive-desktop-core/build/backend';
+import { Result } from '../../../../context/shared/domain/Result';
+import { FuseError } from '../../../../apps/drive/fuse/callbacks/FuseErrors';
+
+export async function getAttributes(
+  path: string,
+  container: Container,
+): Promise<Result<GetAttributesCallbackData, FuseError>> {
+  if (path === '/' || path === '') {
+    return {
+      data: {
+        mode: FOLDER_MODE,
+        size: 0,
+        mtime: new Date(),
+        ctime: new Date(),
+        atime: undefined,
+        uid: process.getuid?.() || 0,
+        gid: process.getgid?.() || 0,
+        nlink: 2,
+      },
+    };
+  }
+
+  const file = await container.get(FirstsFileSearcher).run({
+    path,
+    status: FileStatuses.EXISTS,
+  });
+  if (file) {
+    return {
+      data: {
+        mode: FILE_MODE,
+        size: file.size,
+        ctime: file.createdAt,
+        mtime: file.updatedAt,
+        atime: new Date(),
+        uid: process.getuid?.() || 0,
+        gid: process.getgid?.() || 0,
+        nlink: 1,
+      },
+    };
+  }
+  const folder = await container.get(SingleFolderMatchingSearcher).run({
+    path,
+  });
+  if (folder) {
+    return {
+      data: {
+        mode: FOLDER_MODE,
+        size: 0,
+        ctime: folder.createdAt,
+        mtime: folder.updatedAt,
+        atime: folder.createdAt,
+        uid: process.getuid?.() || 0,
+        gid: process.getgid?.() || 0,
+        nlink: 2,
+      },
+    };
+  }
+  const document = await container.get(TemporalFileByPathFinder).run(path);
+
+  if (document) {
+    return {
+      data: {
+        mode: FILE_MODE,
+        size: document.size.value,
+        mtime: new Date(),
+        ctime: document.createdAt,
+        atime: document.createdAt,
+        uid: process.getuid?.() || 0,
+        gid: process.getgid?.() || 0,
+        nlink: 1,
+      },
+    };
+  }
+  const msg = `[FUSE - GetAttributes] File not found: ${path}`;
+  logger.error({ msg });
+  return { error: new FuseError(FuseCodes.ENOENT, msg) };
+}


### PR DESCRIPTION
## What is Changed / Added
Updated Electron to v21

The FUSE daemon can now answer kernel `getattr` calls, which means the filesystem can report file/directory metadata (size, timestamps, permissions, owner)

Now, Kernel issues getattr(path) and `go-fuse-daemon` receives it then through Unix socket over http, the Express handler normalizes the path and calls `getAttributes(path, container)` which a refactor from the old getAttributes callback from fuse