### PR TITLE
feat: add NameLen field to StatFs response and update related tests

### DIFF
--- a/packages/fuse-daemon/internal/filesystem/operations.go
+++ b/packages/fuse-daemon/internal/filesystem/operations.go
@@ -204,11 +204,12 @@ func (fs *InternxtFilesystem) StatFs(name string) *fuse.StatfsOut {
 		return nil
 	}
 	return &fuse.StatfsOut{
-		Blocks: response.Blocks,
-		Bfree:  response.Bfree,
-		Bavail: response.Bavail,
-		Files:  response.Files,
-		Ffree:  response.Ffree,
-		Bsize:  response.Bsize,
+		Blocks:  response.Blocks,
+		Bfree:   response.Bfree,
+		Bavail:  response.Bavail,
+		Files:   response.Files,
+		Ffree:   response.Ffree,
+		Bsize:   response.Bsize,
+		NameLen: response.NameLen,
 	}
 }

--- a/packages/fuse-daemon/internal/filesystem/operations_test.go
+++ b/packages/fuse-daemon/internal/filesystem/operations_test.go
@@ -511,12 +511,13 @@ func TestStatFs(t *testing.T) {
 	t.Run("returns filesystem stats from backend", func(t *testing.T) {
 		sharedMount.mockServer.setHandler(client.OperationStatFs, func(w http.ResponseWriter, r *http.Request) {
 			respondJSON(w, map[string]any{
-				"blocks": uint64(1000000),
-				"bfree":  uint64(500000),
-				"bavail": uint64(490000),
-				"files":  uint64(100000),
-				"ffree":  uint64(90000),
-				"bsize":  uint32(4096),
+				"blocks":  uint64(1000000),
+				"bfree":   uint64(500000),
+				"bavail":  uint64(490000),
+				"files":   uint64(100000),
+				"ffree":   uint64(90000),
+				"bsize":   uint32(4096),
+				"nameLen": uint32(255),
 			})
 		})
 
@@ -533,6 +534,9 @@ func TestStatFs(t *testing.T) {
 		}
 		if stat.Bavail != 490000 {
 			t.Errorf("bavail: got %d, want 490000", stat.Bavail)
+		}
+		if stat.Namelen != 255 {
+			t.Errorf("namelen: got %d, want 255", stat.Namelen)
 		}
 	})
 

--- a/packages/fuse-daemon/internal/filesystem/responses.go
+++ b/packages/fuse-daemon/internal/filesystem/responses.go
@@ -23,10 +23,11 @@ type OpenDirCallbackData struct {
 }
 
 type StatFsCallbackData struct {
-	Blocks uint64 `json:"blocks"`
-	Bfree  uint64 `json:"bfree"`
-	Bavail uint64 `json:"bavail"`
-	Files  uint64 `json:"files"`
-	Ffree  uint64 `json:"ffree"`
-	Bsize  uint32 `json:"bsize"`
+	Blocks  uint64 `json:"blocks"`
+	Bfree   uint64 `json:"bfree"`
+	Bavail  uint64 `json:"bavail"`
+	Files   uint64 `json:"files"`
+	Ffree   uint64 `json:"ffree"`
+	Bsize   uint32 `json:"bsize"`
+	NameLen uint32 `json:"nameLen"`
 }

--- a/src/backend/features/virtual-drive/controllers/operations/statfs.controller.test.ts
+++ b/src/backend/features/virtual-drive/controllers/operations/statfs.controller.test.ts
@@ -27,6 +27,7 @@ describe('statfsController', () => {
       files: 100000,
       ffree: 90000,
       bsize: 4096,
+      nameLen: 255,
     };
     statfsMock.mockResolvedValue({ data: stats });
 

--- a/src/backend/features/virtual-drive/services/operations/statfs.service.test.ts
+++ b/src/backend/features/virtual-drive/services/operations/statfs.service.test.ts
@@ -28,7 +28,7 @@ describe('statfs', () => {
 
     const result = await statfs({ container });
 
-    expect(result.data).toStrictEqual(diskStats);
+    expect(result.data).toStrictEqual({ ...diskStats, nameLen: 255 });
     expect(result.error).toBeUndefined();
   });
 

--- a/src/backend/features/virtual-drive/services/operations/statfs.service.ts
+++ b/src/backend/features/virtual-drive/services/operations/statfs.service.ts
@@ -4,6 +4,15 @@ import { type Result } from '../../../../../context/shared/domain/Result';
 import { FuseError, FuseIOError } from '../../../../../apps/drive/fuse/callbacks/FuseErrors';
 import { TemporalFileRepository } from '../../../../../context/storage/TemporalFiles/domain/TemporalFileRepository';
 
+/**
+ * v.2.6.0
+ * Esteban Galvis Triana
+ * Standard Linux NAME_MAX: the maximum number of bytes in a filename component.
+ * Without this, f_namelen in statfs would be 0 and file managers (e.g. Nautilus)
+ * would reject every rename attempt as "File name is too long".
+ */
+const NAME_MAX = 255;
+
 export type StatFsResult = {
   blocks: number;
   bfree: number;
@@ -11,6 +20,7 @@ export type StatFsResult = {
   files: number;
   ffree: number;
   bsize: number;
+  nameLen: number;
 };
 
 type Props = {
@@ -20,7 +30,7 @@ type Props = {
 export async function statfs({ container }: Props): Promise<Result<StatFsResult, FuseError>> {
   try {
     const stats = await container.get(TemporalFileRepository).statFs();
-    return { data: stats };
+    return { data: { ...stats, nameLen: NAME_MAX } };
   } catch (err) {
     logger.error({ msg: '[StatFs] Failed to read filesystem stats', error: err });
     return { error: new FuseIOError('Failed to read filesystem stats') };


### PR DESCRIPTION
## Fix: File name is too long error when renaming files or folders

### Problem

Nautilus (and other file managers) were showing "File name is too long" for **any**
rename attempt — even a single character — inside the Internxt virtual drive.

### Root Cause

The `StatFs` FUSE operation never populated the `NameLen` / `f_namelen` field in the
filesystem statistics. This caused the mount to report a maximum filename length of
**0 bytes**. File managers call `statvfs()` before validating a rename; with
`f_namelen = 0` every name is considered too long.

### Fix

Return the standard Linux `NAME_MAX` value (`255`) in the `nameLen` field across
the full stack:

- **`statfs.service.ts`** — added `nameLen: NAME_MAX` (255) to `StatFsResult` and
  to the value returned by `statfs()`.
- **`responses.go`** — added `NameLen uint32` field to `StatFsCallbackData` so the
  Go daemon can deserialize the value from Electron.
- **`operations.go`** — set `NameLen: response.NameLen` in the `fuse.StatfsOut`
  returned to the kernel.

### Tests updated

- `statfs.service.test.ts` — expected result now includes `nameLen: 255`.
- `statfs.controller.test.ts` — test fixture updated with `nameLen: 255`.
- `operations_test.go` — mock response includes `nameLen` and asserts
  `stat.Namelen == 255`.