### PR TITLE
Feat/add thumnails range requests

### DIFF
--- a/src/backend/features/fuse/on-read/handle-read-callback.test.ts
+++ b/src/backend/features/fuse/on-read/handle-read-callback.test.ts
@@ -4,6 +4,7 @@ import * as processBlocklistModule from '../../../features/virtual-drive/utils/p
 import * as fileExistsModule from './download-cache/file-exists-on-disk';
 import * as allocateFileModule from './download-cache/allocate-file';
 import * as downloadAndSaveBlockModule from './download-cache/download-and-save-block';
+import * as downloadFileModule from '../../../../infra/environment/download-file/download-file';
 import {
   clearHydrationState,
   getExistingHydrationState,
@@ -19,6 +20,7 @@ const isBlocklistedProcessMock = partialSpyOn(processBlocklistModule, 'isBlockli
 const fileExistsOnDiskMock = partialSpyOn(fileExistsModule, 'fileExistsOnDisk');
 const allocateFileMock = partialSpyOn(allocateFileModule, 'allocateFile');
 const downloadAndCacheBlockMock = partialSpyOn(downloadAndSaveBlockModule, 'downloadAndCacheBlock');
+const downloadFileRangeMock = partialSpyOn(downloadFileModule, 'downloadFileRange');
 
 const virtualFile = {
   contentsId: 'contents-123',
@@ -147,6 +149,54 @@ describe('handleReadCallback', () => {
       expect(deps.onDownloadProgress).not.toHaveBeenCalled();
       expect(deps.saveToRepository).not.toHaveBeenCalled();
       expect(readChunkFromDiskMock).toHaveBeenCalledWith(expect.stringContaining(virtualFile.contentsId), 10, 0);
+    });
+  });
+
+  describe('when process is a thumbnail generator', () => {
+    it('should download the exact requested range without block expansion', async () => {
+      const chunk = Buffer.from('image-header');
+      downloadFileRangeMock.mockResolvedValue({ data: chunk });
+      const deps = createDeps({ processName: 'pool-org.gnome.', range: { position: 0, length: 32768 } });
+
+      const result = await handleReadCallback(deps);
+
+      expect(result.data).toBe(chunk);
+      call(downloadFileRangeMock).toMatchObject({
+        fileId: virtualFile.contentsId,
+        bucketId: deps.bucketId,
+        mnemonic: deps.mnemonic,
+        range: { position: 0, length: 32768 },
+      });
+    });
+
+    it('should not allocate a cache file or download blocks', async () => {
+      downloadFileRangeMock.mockResolvedValue({ data: Buffer.from('bytes') });
+      const deps = createDeps({ processName: 'pool-org.gnome.' });
+
+      await handleReadCallback(deps);
+
+      expect(fileExistsOnDiskMock).not.toHaveBeenCalled();
+      expect(allocateFileMock).not.toHaveBeenCalled();
+      expect(downloadAndCacheBlockMock).not.toHaveBeenCalled();
+    });
+
+    it('should not emit download progress or register the file', async () => {
+      downloadFileRangeMock.mockResolvedValue({ data: Buffer.from('bytes') });
+      const deps = createDeps({ processName: 'pool-org.gnome.' });
+
+      await handleReadCallback(deps);
+
+      expect(deps.onDownloadProgress).not.toHaveBeenCalled();
+      expect(deps.saveToRepository).not.toHaveBeenCalled();
+    });
+
+    it('should return EIO when the ranged download fails', async () => {
+      downloadFileRangeMock.mockResolvedValue({ error: new Error('network error') });
+      const deps = createDeps({ processName: 'pool-org.gnome.' });
+
+      const result = await handleReadCallback(deps);
+
+      expect(result.error).toBeInstanceOf(FuseIOError);
     });
   });
 

--- a/src/backend/features/fuse/on-read/handle-read-callback.ts
+++ b/src/backend/features/fuse/on-read/handle-read-callback.ts
@@ -1,7 +1,8 @@
 import { logger } from '@internxt/drive-desktop-core/build/backend';
 import { type TemporalFile } from '../../../../context/storage/TemporalFiles/domain/TemporalFile';
 import { type File } from '../../../../context/virtual-drive/files/domain/File';
-import { type FuseError, FuseNoSuchFileOrDirectoryError } from '../../../../apps/drive/fuse/callbacks/FuseErrors';
+import { type FuseError, FuseIOError, FuseNoSuchFileOrDirectoryError } from '../../../../apps/drive/fuse/callbacks/FuseErrors';
+import { downloadFileRange } from '../../../../infra/environment/download-file/download-file';
 import { type Result } from '../../../../context/shared/domain/Result';
 import { readChunkFromDisk } from './read-chunk-from-disk';
 import nodePath from 'node:path';
@@ -9,6 +10,7 @@ import { PATHS } from '../../../../core/electron/paths';
 import { EMPTY } from './constants';
 import { readOrHydrate } from './read-or-hydrate';
 import { type HandleReadDeps, type ReadRange } from './types';
+import { isThumbnailProcess } from './thumbnail-processes';
 export type HandleReadCallbackProps = HandleReadDeps & {
   findVirtualFile: (path: string) => Promise<File | undefined>;
   findTemporalFile: (path: string) => Promise<TemporalFile | undefined>;
@@ -34,11 +36,17 @@ export async function handleReadCallback({
   network,
   path,
   range,
+  processName,
 }: HandleReadCallbackProps): Promise<Result<Buffer, FuseError>> {
   const virtualFile = await findVirtualFile(path);
 
   if (!virtualFile) {
     return readFromTemporalFile(findTemporalFile, path, range.length, range.position);
+  }
+
+  if (isThumbnailProcess(processName)) {
+    logger.debug({ msg: '[ReadCallback] thumbnail process, downloading exact range', process: processName, file: virtualFile.nameWithExtension });
+    return readExactRangeForThumbnail({ bucketId, mnemonic, network, virtualFile, range });
   }
 
   const filePath = nodePath.join(PATHS.DOWNLOADED, virtualFile.contentsId);
@@ -70,4 +78,28 @@ async function readFromTemporalFile(
 
   const chunk = await readChunkFromDisk(temporalFile.contentFilePath, length, position);
   return { data: chunk ?? EMPTY };
+}
+
+type ThumbnailRangeProps = Pick<HandleReadCallbackProps, 'bucketId' | 'mnemonic' | 'network' | 'range'> & {
+  virtualFile: File;
+};
+
+async function readExactRangeForThumbnail({
+  bucketId,
+  mnemonic,
+  network,
+  virtualFile,
+  range,
+}: ThumbnailRangeProps): Promise<Result<Buffer, FuseError>> {
+  const { signal } = new AbortController();
+  const result = await downloadFileRange({
+    fileId: virtualFile.contentsId,
+    bucketId,
+    mnemonic,
+    network,
+    range,
+    signal,
+  });
+  if (result.error) return { error: new FuseIOError(result.error.message) };
+  return { data: result.data };
 }

--- a/src/backend/features/fuse/on-read/handle-read-callback.ts
+++ b/src/backend/features/fuse/on-read/handle-read-callback.ts
@@ -1,7 +1,11 @@
 import { logger } from '@internxt/drive-desktop-core/build/backend';
 import { type TemporalFile } from '../../../../context/storage/TemporalFiles/domain/TemporalFile';
 import { type File } from '../../../../context/virtual-drive/files/domain/File';
-import { type FuseError, FuseIOError, FuseNoSuchFileOrDirectoryError } from '../../../../apps/drive/fuse/callbacks/FuseErrors';
+import {
+  type FuseError,
+  FuseIOError,
+  FuseNoSuchFileOrDirectoryError,
+} from '../../../../apps/drive/fuse/callbacks/FuseErrors';
 import { downloadFileRange } from '../../../../infra/environment/download-file/download-file';
 import { type Result } from '../../../../context/shared/domain/Result';
 import { readChunkFromDisk } from './read-chunk-from-disk';
@@ -45,7 +49,11 @@ export async function handleReadCallback({
   }
 
   if (isThumbnailProcess(processName)) {
-    logger.debug({ msg: '[ReadCallback] thumbnail process, downloading exact range', process: processName, file: virtualFile.nameWithExtension });
+    logger.debug({
+      msg: '[ReadCallback] thumbnail process, downloading exact range',
+      process: processName,
+      file: virtualFile.nameWithExtension,
+    });
     return readExactRangeForThumbnail({ bucketId, mnemonic, network, virtualFile, range });
   }
 

--- a/src/backend/features/fuse/on-read/thumbnail-processes.ts
+++ b/src/backend/features/fuse/on-read/thumbnail-processes.ts
@@ -1,0 +1,24 @@
+/**
+ * Linux's /proc/PID/comm truncates process names to 15 characters.
+ * The names below are the known thumbnailer process names after that truncation.
+ *
+ * Examples of full → truncated names:
+ *   pool-org.gnome.N… → pool-org.gnome.  (GNOME/Nautilus thumbnailer thread pool)
+ *   gnome-thumbnail-factory → gnome-thumbnail
+ *   evince-thumbnailer      → evince-thumbnai
+ *   totem-video-thumbnailer → totem-video-thu
+ *   ffmpegthumbnailer       → ffmpegthumbnaile
+ *   tumbler-1               → tumbler-1
+ */
+const THUMBNAIL_PROCESS_NAMES = new Set([
+  'pool-org.gnome.', // GNOME/Nautilus thumbnailer thread pool (pool-org.gnome.NautilusThumbnailFactory, etc.)
+  'gnome-thumbnail', // gnome-thumbnail-factory (GNOME Files)
+  'evince-thumbnai', // evince-thumbnailer (Evince document viewer)
+  'totem-video-thu', // totem-video-thumbnailer (Totem video)
+  'ffmpegthumbnaile', // ffmpegthumbnailer
+  'tumbler-1', // xfce tumbler
+]);
+
+export function isThumbnailProcess(processName: string): boolean {
+  return THUMBNAIL_PROCESS_NAMES.has(processName);
+}


### PR DESCRIPTION
## What is Changed / Added

This PR improves Virtual Drive read behavior for thumbnail generation in Linux file managers (Nautilus/GNOME thumbnail workers).

Previously, thumbnail-related reads could enter the normal hydration path and trigger block-based downloads that were larger than necessary.  
Now, thumbnail processes are detected and routed through an exact-range read flow so only the requested bytes are downloaded.
