### PR TITLE
fix: update FileTrasher to call remote.trash for zero-byte files

### DIFF
--- a/src/context/virtual-drive/files/application/trash/FileTrasher.test.ts
+++ b/src/context/virtual-drive/files/application/trash/FileTrasher.test.ts
@@ -94,7 +94,7 @@ describe('FileTrasher', () => {
       expect(syncFileMessengerMock.trashed).toBeCalledWith(file.name, file.type, file.size);
     });
 
-    it('should NOT call remote.trash for files with size 0', async () => {
+    it('should call remote.trash for files with size 0', async () => {
       const file = FileMother.fromPartial({ size: 0 });
       fileRepositoryMock.matchingPartial.mockReturnValue([file]);
       allParentFoldersStatusIsExistsMock.run.mockResolvedValue(true);
@@ -102,7 +102,7 @@ describe('FileTrasher', () => {
       await sut.run(file.contentsId);
 
       expect(syncFileMessengerMock.trashing).toBeCalledWith(file.name, file.type, file.size);
-      expect(addFileToTrashMock).not.toBeCalled();
+      call(addFileToTrashMock).toBe(file.uuid);
       expect(fileRepositoryMock.update).toBeCalledWith(expect.objectContaining({ status: FileStatus.Trashed }));
       expect(syncFileMessengerMock.trashed).toBeCalledWith(file.name, file.type, file.size);
     });

--- a/src/context/virtual-drive/files/application/trash/FileTrasher.ts
+++ b/src/context/virtual-drive/files/application/trash/FileTrasher.ts
@@ -46,12 +46,11 @@ export class FileTrasher {
     try {
       file.trash();
 
-      if (file.size > 0) {
-        const { error } = await addFileToTrash(file.uuid);
-        if (error) {
-          throw new Error('Error when deleting file');
-        }
+      const { error } = await addFileToTrash(file.uuid);
+      if (error) {
+        throw new Error('Error when deleting file');
       }
+
       await this.repository.update(file);
       await this.notifier.trashed(file.name, file.type, file.size);
     } catch (error: unknown) {


### PR DESCRIPTION
## What is Changed / Added

- Fixed remote deletion so 0-byte files are also sent to remote trash.
- Removed the size-based condition that skipped remote trash calls for empty files.
- Updated unit tests to assert that 0-byte files now trigger the remote trash request.
