### PR TITLE
feat: add deleteByFolderPath method to FileRepository and implement i…

### DIFF
--- a/src/context/virtual-drive/files/__mocks__/FileRepositoryMock.ts
+++ b/src/context/virtual-drive/files/__mocks__/FileRepositoryMock.ts
@@ -11,6 +11,7 @@ export class FileRepositoryMock implements FileRepository {
   public readonly deleteMock = vi.fn();
   public readonly addMock = vi.fn();
   public readonly updateMock = vi.fn();
+  public readonly deleteByFolderPathMock = vi.fn();
   public readonly clearMock = vi.fn();
 
   all(): Promise<File[]> {
@@ -47,6 +48,10 @@ export class FileRepositoryMock implements FileRepository {
 
   update(file: File): Promise<void> {
     return this.updateMock(file);
+  }
+
+  deleteByFolderPath(folderPath: string): Promise<void> {
+    return this.deleteByFolderPathMock(folderPath);
   }
 
   clear(): Promise<void> {

--- a/src/context/virtual-drive/files/domain/FileRepository.ts
+++ b/src/context/virtual-drive/files/domain/FileRepository.ts
@@ -18,5 +18,7 @@ export abstract class FileRepository {
 
   abstract update(file: File): Promise<void>;
 
+  abstract deleteByFolderPath(folderPath: string): Promise<void>;
+
   abstract clear(): Promise<void>;
 }

--- a/src/context/virtual-drive/files/infrastructure/InMemoryFileRepository.test.ts
+++ b/src/context/virtual-drive/files/infrastructure/InMemoryFileRepository.test.ts
@@ -383,4 +383,68 @@ describe('InMemoryFileRepository', () => {
       expect(result.map((f) => f.uuid)).not.toContain('550e8400-e29b-41d4-a716-446655440002');
     });
   });
+
+  describe('deleteByFolderPath', () => {
+    const makeFile = (uuid: string, contentsId: string, path: string) =>
+      File.from({
+        id: 1,
+        uuid,
+        contentsId,
+        folderId: 100,
+        createdAt: '10-03-2025',
+        modificationTime: '10-03-2025',
+        path,
+        size: 1000,
+        updatedAt: '10-03-2025',
+        status: FileStatuses.EXISTS,
+      });
+
+    it('should remove direct children of the deleted folder', async () => {
+      await sut.upsert(makeFile('550e8400-e29b-41d4-a716-446655440010', '21e5ac20-4d87-4458-0010-', '/photos/a.jpg'));
+      await sut.upsert(makeFile('550e8400-e29b-41d4-a716-446655440011', '21e5ac20-4d87-4458-0011-', '/photos/b.jpg'));
+
+      await sut.deleteByFolderPath('/photos');
+
+      expect(await sut.searchByUuid('550e8400-e29b-41d4-a716-446655440010')).toBeUndefined();
+      expect(await sut.searchByUuid('550e8400-e29b-41d4-a716-446655440011')).toBeUndefined();
+    });
+
+    it('should remove files in nested subfolders', async () => {
+      await sut.upsert(makeFile('550e8400-e29b-41d4-a716-446655440012', '21e5ac20-4d87-4458-0012-', '/photos/2024/a.jpg'));
+      await sut.upsert(makeFile('550e8400-e29b-41d4-a716-446655440013', '21e5ac20-4d87-4458-0013-', '/photos/2024/summer/b.jpg'));
+
+      await sut.deleteByFolderPath('/photos');
+
+      expect(await sut.searchByUuid('550e8400-e29b-41d4-a716-446655440012')).toBeUndefined();
+      expect(await sut.searchByUuid('550e8400-e29b-41d4-a716-446655440013')).toBeUndefined();
+    });
+
+    it('should not remove files from folders with a similar name prefix', async () => {
+      await sut.upsert(makeFile('550e8400-e29b-41d4-a716-446655440014', '21e5ac20-4d87-4458-0014-', '/photos/a.jpg'));
+      await sut.upsert(makeFile('550e8400-e29b-41d4-a716-446655440015', '21e5ac20-4d87-4458-0015-', '/photos-backup/b.jpg'));
+
+      await sut.deleteByFolderPath('/photos');
+
+      expect(await sut.searchByUuid('550e8400-e29b-41d4-a716-446655440014')).toBeUndefined();
+      expect(await sut.searchByUuid('550e8400-e29b-41d4-a716-446655440015')).toBeDefined();
+    });
+
+    it('should not remove files from unrelated folders', async () => {
+      await sut.upsert(makeFile('550e8400-e29b-41d4-a716-446655440016', '21e5ac20-4d87-4458-0016-', '/photos/a.jpg'));
+      await sut.upsert(makeFile('550e8400-e29b-41d4-a716-446655440017', '21e5ac20-4d87-4458-0017-', '/documents/report.pdf'));
+
+      await sut.deleteByFolderPath('/photos');
+
+      expect(await sut.searchByUuid('550e8400-e29b-41d4-a716-446655440016')).toBeUndefined();
+      expect(await sut.searchByUuid('550e8400-e29b-41d4-a716-446655440017')).toBeDefined();
+    });
+
+    it('should do nothing when no files match the folder path', async () => {
+      await sut.upsert(makeFile('550e8400-e29b-41d4-a716-446655440018', '21e5ac20-4d87-4458-0018-', '/documents/report.pdf'));
+
+      await sut.deleteByFolderPath('/photos');
+
+      expect(await sut.searchByUuid('550e8400-e29b-41d4-a716-446655440018')).toBeDefined();
+    });
+  });
 });

--- a/src/context/virtual-drive/files/infrastructure/InMemoryFileRepository.test.ts
+++ b/src/context/virtual-drive/files/infrastructure/InMemoryFileRepository.test.ts
@@ -410,8 +410,12 @@ describe('InMemoryFileRepository', () => {
     });
 
     it('should remove files in nested subfolders', async () => {
-      await sut.upsert(makeFile('550e8400-e29b-41d4-a716-446655440012', '21e5ac20-4d87-4458-0012-', '/photos/2024/a.jpg'));
-      await sut.upsert(makeFile('550e8400-e29b-41d4-a716-446655440013', '21e5ac20-4d87-4458-0013-', '/photos/2024/summer/b.jpg'));
+      await sut.upsert(
+        makeFile('550e8400-e29b-41d4-a716-446655440012', '21e5ac20-4d87-4458-0012-', '/photos/2024/a.jpg'),
+      );
+      await sut.upsert(
+        makeFile('550e8400-e29b-41d4-a716-446655440013', '21e5ac20-4d87-4458-0013-', '/photos/2024/summer/b.jpg'),
+      );
 
       await sut.deleteByFolderPath('/photos');
 
@@ -421,7 +425,9 @@ describe('InMemoryFileRepository', () => {
 
     it('should not remove files from folders with a similar name prefix', async () => {
       await sut.upsert(makeFile('550e8400-e29b-41d4-a716-446655440014', '21e5ac20-4d87-4458-0014-', '/photos/a.jpg'));
-      await sut.upsert(makeFile('550e8400-e29b-41d4-a716-446655440015', '21e5ac20-4d87-4458-0015-', '/photos-backup/b.jpg'));
+      await sut.upsert(
+        makeFile('550e8400-e29b-41d4-a716-446655440015', '21e5ac20-4d87-4458-0015-', '/photos-backup/b.jpg'),
+      );
 
       await sut.deleteByFolderPath('/photos');
 
@@ -431,7 +437,9 @@ describe('InMemoryFileRepository', () => {
 
     it('should not remove files from unrelated folders', async () => {
       await sut.upsert(makeFile('550e8400-e29b-41d4-a716-446655440016', '21e5ac20-4d87-4458-0016-', '/photos/a.jpg'));
-      await sut.upsert(makeFile('550e8400-e29b-41d4-a716-446655440017', '21e5ac20-4d87-4458-0017-', '/documents/report.pdf'));
+      await sut.upsert(
+        makeFile('550e8400-e29b-41d4-a716-446655440017', '21e5ac20-4d87-4458-0017-', '/documents/report.pdf'),
+      );
 
       await sut.deleteByFolderPath('/photos');
 
@@ -440,7 +448,9 @@ describe('InMemoryFileRepository', () => {
     });
 
     it('should do nothing when no files match the folder path', async () => {
-      await sut.upsert(makeFile('550e8400-e29b-41d4-a716-446655440018', '21e5ac20-4d87-4458-0018-', '/documents/report.pdf'));
+      await sut.upsert(
+        makeFile('550e8400-e29b-41d4-a716-446655440018', '21e5ac20-4d87-4458-0018-', '/documents/report.pdf'),
+      );
 
       await sut.deleteByFolderPath('/photos');
 

--- a/src/context/virtual-drive/files/infrastructure/InMemoryFileRepository.ts
+++ b/src/context/virtual-drive/files/infrastructure/InMemoryFileRepository.ts
@@ -112,6 +112,22 @@ export class InMemoryFileRepository implements FileRepository {
     this.upsert(file);
   }
 
+  async deleteByFolderPath(folderPath: string): Promise<void> {
+    const prefix = folderPath.endsWith('/') ? folderPath : `${folderPath}/`;
+    const toDelete: Array<{ uuid: string; contentsId: string }> = [];
+
+    for (const [uuid, attributes] of this.filesByUuid) {
+      if (attributes.path.startsWith(prefix)) {
+        toDelete.push({ uuid, contentsId: attributes.contentsId });
+      }
+    }
+
+    for (const { uuid, contentsId } of toDelete) {
+      this.filesByUuid.delete(uuid);
+      this.filesByContentsId.delete(contentsId);
+    }
+  }
+
   async clear(): Promise<void> {
     this.filesByUuid.clear();
     this.filesByContentsId.clear();

--- a/src/context/virtual-drive/folders/application/FolderDeleter.ts
+++ b/src/context/virtual-drive/folders/application/FolderDeleter.ts
@@ -7,6 +7,7 @@ import { FolderNotFoundError } from '../domain/errors/FolderNotFoundError';
 import { LocalFileSystem } from '../domain/file-systems/LocalFileSystem';
 import { AllParentFoldersStatusIsExists } from './AllParentFoldersStatusIsExists';
 import { addFolderToTrash } from '../../../../infra/drive-server/services/folder/services/add-folder-to-trash';
+import { FileRepository } from '../../files/domain/FileRepository';
 
 @Service()
 export class FolderDeleter {
@@ -14,6 +15,7 @@ export class FolderDeleter {
     private readonly repository: FolderRepository,
     private readonly local: LocalFileSystem,
     private readonly allParentFoldersStatusIsExists: AllParentFoldersStatusIsExists,
+    private readonly fileRepository: FileRepository,
   ) {}
 
   async run(uuid: Folder['uuid']): Promise<void> {
@@ -51,6 +53,7 @@ export class FolderDeleter {
         throw new Error('Error when deleting folder');
       }
       await this.repository.delete(folder.id);
+      await this.fileRepository.deleteByFolderPath(folder.path);
     } catch (error: unknown) {
       logger.error({
         msg: `Error deleting the folder ${folder.name}:`,


### PR DESCRIPTION
## What is Changed / Added
- Added `deleteByFolderPath(folderPath: string)` method to `FileRepository` and `InMemoryFileRepository`
- `FolderDeleter` now evicts all child file entries from `InMemoryFileRepository` immediately after a folder is trashed
----
## Why
When a folder was deleted and immediately re-uploaded, the app incorrectly showed a "Replace?" conflict dialog for every file inside it. Accepting the replace then failed silently.

**Root cause:** `FolderDeleter` removed the folder from `InMemoryFolderRepository` but never touched `InMemoryFileRepository`. The child files remained in memory with `status = EXISTS` until the next remote sync cycle. Because FUSE's `GetAttributesCallback` queries this in-memory state, it reported the deleted files as still existing to the kernel, causing Nautilus to show the conflict dialog. When the user accepted, `UploadOnRename` tried to override the file using its old `contentsId` (already trashed on the server), which the server correctly rejected.

**Fix:** After successfully trashing a folder on the server and removing it from the folder repository, `FolderDeleter` now calls `fileRepository.deleteByFolderPath(folder.path)` to evict all stale child file entries from memory. This keeps local state consistent immediately, without waiting for the next sync.