### PR TITLE
fix: improve tray menu state management to prevent rapid icon flickering during concurrent sync operations

### DIFF
--- a/src/apps/main/tray/tray-menu.test.ts
+++ b/src/apps/main/tray/tray-menu.test.ts
@@ -1,3 +1,4 @@
+import { calls } from 'tests/vitest/utils.helper';
 import PackageJson from '../../../../package.json';
 
 const { trayHandlers, trayInstance, buildFromTemplateMock, createFromPathMock, TrayMock } = vi.hoisted(() => {
@@ -95,5 +96,20 @@ describe('tray-menu', () => {
 
     // Then
     expect(trayInstance.setToolTip).toBeCalledWith(`Internxt ${PackageJson.version}`);
+  });
+
+  it('should not update the image or tooltip when called with the same state twice', () => {
+    // Given
+    const trayMenu = new TrayMenu('/icons', vi.fn().mockResolvedValue(undefined), vi.fn());
+    trayMenu.setState('SYNCING'); // first call — state changes LOADING→SYNCING
+    trayInstance.setImage.mockClear();
+    trayInstance.setToolTip.mockClear();
+
+    // When — same state again
+    trayMenu.setState('SYNCING');
+
+    // Then — no native tray calls should be made
+    calls(trayInstance.setImage).toHaveLength(0);
+    calls(trayInstance.setToolTip).toHaveLength(0);
   });
 });

--- a/src/apps/main/tray/tray-menu.ts
+++ b/src/apps/main/tray/tray-menu.ts
@@ -5,6 +5,7 @@ import { TrayMenuState } from './types';
 
 export class TrayMenu {
   private readonly tray: Tray;
+  private currentState: TrayMenuState | null = null;
 
   get bounds() {
     return this.tray.getBounds();
@@ -43,6 +44,9 @@ export class TrayMenu {
   }
 
   setState(state: TrayMenuState) {
+    if (state === this.currentState) return;
+    this.currentState = state;
+
     const iconPath = this.getIconPath(state);
     this.setImage(iconPath);
 

--- a/src/apps/main/tray/tray-setup.test.ts
+++ b/src/apps/main/tray/tray-setup.test.ts
@@ -114,6 +114,81 @@ describe('tray-setup', () => {
     call(trayMenuInstance.setState).toBe('SYNCING');
   });
 
+  it('should suppress IDLE when another sync operation is still in progress', async () => {
+    // Given
+    const traySetup = await importTraySetup();
+    traySetup.setupTrayIcon();
+    trayMenuInstance.setState.mockClear();
+
+    traySetup.setTrayStatus('SYNCING'); // file A starts
+    traySetup.setTrayStatus('SYNCING'); // file B starts
+
+    // When — file A finishes but file B is still running
+    traySetup.setTrayStatus('IDLE');
+
+    // Then — icon must NOT flip back to IDLE while file B is still syncing
+    const idleCalls = trayMenuInstance.setState.mock.calls.filter(([s]: [string]) => s === 'IDLE');
+    expect(idleCalls).toHaveLength(0);
+  });
+
+  it('should show IDLE once the last sync operation completes', async () => {
+    // Given
+    const traySetup = await importTraySetup();
+    traySetup.setupTrayIcon();
+
+    traySetup.setTrayStatus('SYNCING'); // file A starts
+    traySetup.setTrayStatus('SYNCING'); // file B starts
+    traySetup.setTrayStatus('IDLE');    // file A finishes
+    trayMenuInstance.setState.mockClear();
+
+    // When — file B finishes (counter reaches 0)
+    traySetup.setTrayStatus('IDLE');
+
+    // Then
+    call(trayMenuInstance.setState).toBe('IDLE');
+  });
+
+  it('should decrement the counter on ALERT so IDLE can be reached', async () => {
+    // Given
+    const traySetup = await importTraySetup();
+    traySetup.setupTrayIcon();
+
+    traySetup.setTrayStatus('SYNCING'); // file A starts
+    traySetup.setTrayStatus('SYNCING'); // file B starts
+    // file A errors — should still decrement so file B's IDLE can reach zero
+    traySetup.setTrayStatus('ALERT');
+    trayMenuInstance.setState.mockClear();
+
+    // When — file B finishes
+    traySetup.setTrayStatus('IDLE');
+
+    // Then
+    call(trayMenuInstance.setState).toBe('IDLE');
+  });
+
+  it('resetTrayStatus should force IDLE regardless of active sync count', async () => {
+    // Given
+    const traySetup = await importTraySetup();
+    traySetup.setupTrayIcon();
+
+    traySetup.setTrayStatus('SYNCING');
+    traySetup.setTrayStatus('SYNCING'); // two operations in flight
+    trayMenuInstance.setState.mockClear();
+
+    // When — session ends (logout)
+    traySetup.resetTrayStatus('IDLE');
+
+    // Then — icon must be IDLE immediately
+    call(trayMenuInstance.setState).toBe('IDLE');
+
+    // And the counter is reset so subsequent single operations work normally
+    trayMenuInstance.setState.mockClear();
+    traySetup.setTrayStatus('SYNCING');
+    trayMenuInstance.setState.mockClear();
+    traySetup.setTrayStatus('IDLE');
+    call(trayMenuInstance.setState).toBe('IDLE');
+  });
+
   it('should show auth window when clicking the tray while logged out', async () => {
     // Given
     mockGetIsLoggedIn.mockReturnValue(false);

--- a/src/apps/main/tray/tray-setup.test.ts
+++ b/src/apps/main/tray/tray-setup.test.ts
@@ -138,7 +138,7 @@ describe('tray-setup', () => {
 
     traySetup.setTrayStatus('SYNCING'); // file A starts
     traySetup.setTrayStatus('SYNCING'); // file B starts
-    traySetup.setTrayStatus('IDLE');    // file A finishes
+    traySetup.setTrayStatus('IDLE'); // file A finishes
     trayMenuInstance.setState.mockClear();
 
     // When — file B finishes (counter reaches 0)

--- a/src/apps/main/tray/tray-setup.ts
+++ b/src/apps/main/tray/tray-setup.ts
@@ -9,11 +9,32 @@ import { PATHS } from '../../../core/electron/paths';
 
 let tray: TrayMenu | null = null;
 
+// v.2.6.0
+// Esteban Galvis Triana
+// Tracks the number of concurrent sync operations in progress.
+// The tray only transitions to IDLE when this counter reaches zero, preventing
+// rapid icon flickering when many files are synced concurrently.
+let activeSyncCount = 0;
+
 export function getTray() {
   return tray;
 }
 
-export function setTrayStatus(status: TrayMenuState) {
+export function setTrayStatus(status: Exclude<TrayMenuState, 'LOADING'>) {
+  if (status === 'SYNCING') {
+    activeSyncCount++;
+    tray?.setState('SYNCING');
+  } else if (status === 'IDLE') {
+    activeSyncCount = Math.max(0, activeSyncCount - 1);
+    if (activeSyncCount === 0) tray?.setState('IDLE');
+  } else if (status === 'ALERT') {
+    activeSyncCount = Math.max(0, activeSyncCount - 1);
+    tray?.setState('ALERT');
+  }
+}
+
+export function resetTrayStatus(status: TrayMenuState) {
+  activeSyncCount = 0;
   tray?.setState(status);
 }
 

--- a/src/core/bootstrap/register-app-ready-flow.ts
+++ b/src/core/bootstrap/register-app-ready-flow.ts
@@ -3,7 +3,7 @@ import { logger } from '@internxt/drive-desktop-core/build/backend';
 import eventBus from '../../apps/main/event-bus';
 import { getIsLoggedIn } from '../../apps/main/auth/handlers';
 import { createAuthWindow } from '../../apps/main/windows/auth';
-import { setupTrayIcon, setTrayStatus } from '../../apps/main/tray/tray-setup';
+import { setupTrayIcon, resetTrayStatus } from '../../apps/main/tray/tray-setup';
 import { broadcastToWindows } from '../../apps/main/windows';
 import { setupThemeListener } from '../theme';
 import { registerAvailableUserProductsHandlers } from '../../backend/features/payments/ipc/register-available-user-products-handlers';
@@ -40,7 +40,7 @@ export function registerAppReadyFlow() {
 
       if (!isLoggedIn) {
         await createAuthWindow();
-        setTrayStatus('IDLE');
+        resetTrayStatus('IDLE');
       }
 
       await checkForUpdates({

--- a/src/core/bootstrap/register-session-event-handlers.ts
+++ b/src/core/bootstrap/register-session-event-handlers.ts
@@ -4,7 +4,7 @@ import { AppDataSource, resetAppDataSourceOnLogout } from '../../apps/main/datab
 import { getOrCreateWidged, getWidget, setBoundsOfWidgetByPath } from '../../apps/main/windows/widget';
 import { createAuthWindow, getAuthWindow } from '../../apps/main/windows/auth';
 import configStore from '../../apps/main/config';
-import { getTray, setTrayStatus } from '../../apps/main/tray/tray-setup';
+import { getTray, resetTrayStatus } from '../../apps/main/tray/tray-setup';
 import { openOnboardingWindow } from '../../apps/main/windows/onboarding';
 import { getTheme } from '../theme';
 import { getAntivirusManager } from '../../apps/main/antivirus/antivirusManager';
@@ -30,7 +30,7 @@ async function onUserLoggedIn() {
 
     getTheme();
 
-    setTrayStatus('IDLE');
+    resetTrayStatus('IDLE');
     const widget = await getOrCreateWidged();
     const tray = getTray();
     if (widget && tray) {
@@ -62,7 +62,7 @@ async function onUserLoggedIn() {
 }
 
 async function onUserLoggedOut() {
-  setTrayStatus('IDLE');
+  resetTrayStatus('IDLE');
   const widget = getWidget();
 
   if (widget) {


### PR DESCRIPTION
## What is Changed / Added

Added a two-layer fix in the tray icon module to prevent flickering when many files are synced concurrently:

**1. Reference counter in `setTrayStatus` (`tray-setup.ts`)**
- Introduced `activeSyncCount` to track the number of in-flight sync operations.
- `SYNCING` increments the counter and updates the tray immediately.
- `IDLE` decrements the counter and only updates the tray when the counter reaches zero (all operations finished).
- `ALERT` also decrements the counter, since an error terminates its associated operation.
- Added `resetTrayStatus()` for session boundaries (login/logout) to force a state and reset the counter, preventing the icon from getting stuck on SYNCING after a logout mid-upload.

**2. State deduplication in `TrayMenu.setState` (`tray-menu.ts`)**
- Added `currentState` field to `TrayMenu`.
- `setState` now returns early when called with the state that is already displayed, skipping the native `setImage` and `setToolTip` calls entirely.

Session boundary call sites (`register-session-event-handlers.ts`, `register-app-ready-flow.ts`) updated to use `resetTrayStatus` instead of `setTrayStatus` on login/logout.

---

## Why

On Linux, Electron's tray relies on the AppIndicator/StatusNotifierItem DBus protocol. Every call to `tray.setImage()` sends a DBus message that causes the system tray to fully re-render, which momentarily dismisses any open popup menu.

Previously, each individual file operation called `setTrayStatus('SYNCING')` on start and `setTrayStatus('IDLE')` on completion. When uploading a folder with many files, or pasting multiple files at once onto the virtual drive, this produced rapid SYNCING → IDLE → SYNCING → IDLE cycles — one full cycle per file. Each cycle triggered two `setImage` calls, causing the tray menu to flicker uncontrollably and become unclickable.

With both fixes combined, the number of real `setImage` calls is capped at two for any batch of concurrent operations: one when the first operation starts (IDLE → SYNCING) and one when the last one finishes (SYNCING → IDLE).