### PR TITLE
fix: enhance error handling for network and server errors in retry logic

### DIFF
--- a/src/context/virtual-drive/folders/infrastructure/HttpRemoteFileSystem.ts
+++ b/src/context/virtual-drive/folders/infrastructure/HttpRemoteFileSystem.ts
@@ -69,9 +69,11 @@ export class HttpRemoteFileSystem implements RemoteFileSystem {
       if (error.cause === 'TOO_MANY_REQUESTS') {
         return left(new DriveDesktopError('RATE_LIMITED', String(parseRetryAfterMs(error.message))));
       }
-      if (error.cause === 'SERVER_ERROR') {
+      if (error.cause === 'NETWORK_ERROR' || error.cause === 'SERVER_ERROR') {
         return left(new DriveDesktopError('INTERNAL_SERVER_ERROR'));
       }
+
+      return left(new DriveDesktopError('UNKNOWN'));
     }
     return left(new DriveDesktopError('UNKNOWN'));
   }

--- a/src/infra/drive-server/drive-server.client.ts
+++ b/src/infra/drive-server/drive-server.client.ts
@@ -147,9 +147,11 @@ export function createClient<T>(opts: ClientOptions) {
       if (isAxiosError(error)) {
         const status = error.response?.status;
         const message = error.response?.data?.message ?? error.message;
-        const cause = status ? mapStatusToErrorCause(status) : 'UNKNOWN';
+        const cause = status ? mapStatusToErrorCause(status) : 'NETWORK_ERROR';
+
         return { error: new DriveServerError(cause, status, message) };
       }
+
       return {
         error: new DriveServerError('UNKNOWN', undefined, error instanceof Error ? error.message : 'Unexpected error'),
       };


### PR DESCRIPTION
## What is Changed / Added
- Updated Drive client error mapping to classify transport-level failures without an HTTP response/status as `NETWORK_ERROR`.
- Updated folder creation error mapping so `NETWORK_ERROR` is treated as transient and routed through the same retry path as server-side transient failures.
- Validated the change with focused tests for interceptor/client behavior and folder creation flow.

## Why
- When copying folders from the file manager, `mkdir` could fail on the first attempt and then succeed on manual retry.
- Logs showed the underlying cause was a transport timeout (for example `ETIMEDOUT`) on `POST /folders`, meaning a network failure with no HTTP status.
- Previously, this scenario was not handled as a transient retryable error in the folder creation flow, so it surfaced as a final user-facing failure.
- With this change, status-less network failures are retried automatically, reducing intermittent folder creation/upload failures and improving user experience.