### PR TITLE
[PB-6335] Retrieve and store max file size limits

### DIFF
--- a/src/apps/drive/fuse/callbacks/FuseCodes.ts
+++ b/src/apps/drive/fuse/callbacks/FuseCodes.ts
@@ -11,6 +11,9 @@ export const FuseCodes = {
   // Input/output error
   EIO: 5,
 
+  // File too large
+  EFBIG: 27,
+
   // Invalid argument
   EINVAL: 22,
 

--- a/src/apps/main/auth/service.test.ts
+++ b/src/apps/main/auth/service.test.ts
@@ -95,6 +95,7 @@ describe('saveConfig and canHisConfigBeRestored', () => {
       lastOnboardingShown: '2025-01-01',
       nautilusExtensionVersion: 0,
       discoveredBackup: 1,
+      maxUploadFileSizeInBytes: 1024,
       savedConfigs: {},
       newToken: 'fake-new-token',
       newTokenEncrypted: false,
@@ -113,6 +114,7 @@ describe('saveConfig and canHisConfigBeRestored', () => {
     expect(savedConfigs[fakeUuid].backupList).toStrictEqual(fakeBackupList);
 
     expect(savedConfigs[fakeUuid].deviceUUID).toBe(fakeDeviceUUID);
+    expect(savedConfigs[fakeUuid].maxUploadFileSizeInBytes).toBe(1024);
 
     for (const field of fieldsToSave) {
       expect(savedConfigs[fakeUuid]).toHaveProperty(field);
@@ -121,6 +123,7 @@ describe('saveConfig and canHisConfigBeRestored', () => {
     expect(configState.backupList).toStrictEqual(defaults.backupList);
 
     expect(configState.deviceUUID).toStrictEqual(defaults.deviceUUID);
+    expect(configState.maxUploadFileSizeInBytes).toStrictEqual(defaults.maxUploadFileSizeInBytes);
   });
 
   it('should restore backupList and deviceUUID from savedConfigs on re-login', () => {
@@ -138,6 +141,8 @@ describe('saveConfig and canHisConfigBeRestored', () => {
         lastOnboardingShown: '2025-01-01',
         nautilusExtensionVersion: 0,
         discoveredBackup: 1,
+        backgroundScanEnabled: true,
+        maxUploadFileSizeInBytes: 1024,
       },
     };
 
@@ -145,6 +150,7 @@ describe('saveConfig and canHisConfigBeRestored', () => {
       savedConfigs,
       backupList: {},
       deviceUUID: '',
+      maxUploadFileSizeInBytes: defaults.maxUploadFileSizeInBytes,
     });
 
     mockStoreForState(configState);
@@ -156,6 +162,7 @@ describe('saveConfig and canHisConfigBeRestored', () => {
     expect(configState.backupList).toStrictEqual(fakeBackupList);
 
     expect(configState.deviceUUID).toStrictEqual(fakeDeviceUUID);
+    expect(configState.maxUploadFileSizeInBytes).toBe(1024);
   });
 
   it('should return false when no saved config exists for uuid', () => {
@@ -188,6 +195,7 @@ describe('saveConfig and canHisConfigBeRestored', () => {
       lastOnboardingShown: '2025-01-01',
       nautilusExtensionVersion: 0,
       discoveredBackup: 1,
+      maxUploadFileSizeInBytes: 1024,
       savedConfigs: {},
       newToken: 'fake-new-token',
       newTokenEncrypted: false,
@@ -201,6 +209,7 @@ describe('saveConfig and canHisConfigBeRestored', () => {
 
     expect(configState.backupList).toStrictEqual({});
     expect(configState.deviceUUID).toStrictEqual('');
+    expect(configState.maxUploadFileSizeInBytes).toBe(defaults.maxUploadFileSizeInBytes);
 
     const restored = canHisConfigBeRestored({ uuid: fakeUuid });
 
@@ -208,5 +217,6 @@ describe('saveConfig and canHisConfigBeRestored', () => {
     expect(configState.backupList).toStrictEqual(fakeBackupList);
     expect(configState.deviceUUID).toStrictEqual(fakeDeviceUUID);
     expect(configState.backupsEnabled).toBe(true);
+    expect(configState.maxUploadFileSizeInBytes).toBe(1024);
   });
 });

--- a/src/apps/main/config.ts
+++ b/src/apps/main/config.ts
@@ -36,6 +36,7 @@ const schema: Schema<AppStore> = {
   nautilusExtensionVersion: { type: 'number' },
   discoveredBackup: { type: 'number' },
   availableUserProducts: { type: 'object' },
+  maxUploadFileSizeInBytes: { type: 'number' },
 } as const;
 
 const configStore = new Store<AppStore>({

--- a/src/apps/main/config/save-config.ts
+++ b/src/apps/main/config/save-config.ts
@@ -14,6 +14,7 @@ export const savedConfigFields = [
   'backupList',
   'nautilusExtensionVersion',
   'discoveredBackup',
+  'maxUploadFileSizeInBytes',
 ] as (keyof SavedConfig)[];
 
 export function saveConfig({ uuid }: { uuid: string }) {
@@ -33,6 +34,7 @@ export function saveConfig({ uuid }: { uuid: string }) {
     backupList: ConfigStore.get('backupList'),
     nautilusExtensionVersion: ConfigStore.get('nautilusExtensionVersion'),
     discoveredBackup: ConfigStore.get('discoveredBackup'),
+    maxUploadFileSizeInBytes: ConfigStore.get('maxUploadFileSizeInBytes'),
   };
 
   ConfigStore.set('savedConfigs', {

--- a/src/apps/main/realtime.ts
+++ b/src/apps/main/realtime.ts
@@ -5,6 +5,7 @@ import eventBus from './event-bus';
 import { broadcastToWindows } from './windows';
 import { logger } from '@internxt/drive-desktop-core/build/backend';
 import { getUserAvailableProductsAndStore } from '../../backend/features/payments/services/get-user-available-products-and-store';
+import { resolveUserFileSizeLimit } from '../../backend/features/user/file-size-limit/resolve-user-file-size-limit';
 
 type XHRRequest = {
   getResponseHeader: (headerName: string) => string[] | null;
@@ -102,6 +103,7 @@ function cleanAndStartRemoteNotifications() {
 
     if (eventPayload.eventName === 'PLAN_UPDATED') {
       void getUserAvailableProductsAndStore();
+      void resolveUserFileSizeLimit();
     }
 
     broadcastToWindows('remote-changes', eventPayload);

--- a/src/backend/features/user/file-size-limit/resolve-user-file-size-limit.test.ts
+++ b/src/backend/features/user/file-size-limit/resolve-user-file-size-limit.test.ts
@@ -1,0 +1,66 @@
+import { loggerMock } from '../../../../../tests/vitest/mocks.helper';
+import { partialSpyOn, call } from '../../../../../tests/vitest/utils.helper';
+import configStore from '../../../../apps/main/config';
+import { DriveServerError } from '../../../../infra/drive-server/drive-server.error';
+import * as getUserFileSizeLimitModule from '../../../../infra/drive-server/services/files/services/get-user-file-size-limit';
+import { resolveUserFileSizeLimit } from './resolve-user-file-size-limit';
+
+describe('resolveUserFileSizeLimit', () => {
+  const getUserFileSizeLimitMock = partialSpyOn(getUserFileSizeLimitModule, 'getUserFileSizeLimit');
+  const configGetMock = partialSpyOn(configStore, 'get');
+  const configSetMock = partialSpyOn(configStore, 'set');
+
+  it('should return and store a fresh valid user file size limit', async () => {
+    getUserFileSizeLimitMock.mockResolvedValue({ data: 1024 });
+
+    const result = await resolveUserFileSizeLimit();
+
+    expect(result).toStrictEqual({
+      data: 1024,
+    });
+    call(configSetMock).toStrictEqual(['maxUploadFileSizeInBytes', 1024]);
+    call(loggerMock.debug).toMatchObject({
+      tag: 'SYNC-ENGINE',
+      msg: 'Resolved user file size limit from API',
+    });
+  });
+
+  it('should return stored limit when fresh request fails', async () => {
+    getUserFileSizeLimitMock.mockResolvedValue({ error: new DriveServerError('NETWORK_ERROR', 500, 'Network error') });
+    configGetMock.mockReturnValue(1024);
+
+    const result = await resolveUserFileSizeLimit();
+
+    expect(result).toStrictEqual({
+      data: 1024,
+    });
+    expect(configSetMock).not.toBeCalled();
+    call(loggerMock.warn).toMatchObject({
+      tag: 'SYNC-ENGINE',
+      msg: 'Using stored user file size limit',
+    });
+  });
+
+  it('should return stored limit when fresh limit is invalid', async () => {
+    getUserFileSizeLimitMock.mockResolvedValue({ data: 0 });
+    configGetMock.mockReturnValue(1024);
+
+    const result = await resolveUserFileSizeLimit();
+
+    expect(result).toStrictEqual({
+      data: 1024,
+    });
+    expect(configSetMock).not.toBeCalled();
+  });
+
+  it('should not return invalid stored limit', async () => {
+    const error = new DriveServerError('NETWORK_ERROR', 500, 'Network error');
+    getUserFileSizeLimitMock.mockResolvedValue({ error });
+    configGetMock.mockReturnValue(0);
+
+    const result = await resolveUserFileSizeLimit();
+
+    expect(result.error).toBe(error);
+    expect(result.data).toBeUndefined();
+  });
+});

--- a/src/backend/features/user/file-size-limit/resolve-user-file-size-limit.ts
+++ b/src/backend/features/user/file-size-limit/resolve-user-file-size-limit.ts
@@ -1,0 +1,39 @@
+import { logger } from '@internxt/drive-desktop-core/build/backend';
+import configStore from '../../../../apps/main/config';
+import { Result } from '../../../../context/shared/domain/Result';
+import { getUserFileSizeLimit } from '../../../../infra/drive-server/services/files/services/get-user-file-size-limit';
+import { UserFileSizeLimit } from '../../../../infra/drive-server/out/dto';
+
+export async function resolveUserFileSizeLimit(): Promise<Result<Exclude<UserFileSizeLimit, null>, Error>> {
+  const { data, error } = await getUserFileSizeLimit();
+
+  if (data) {
+    configStore.set('maxUploadFileSizeInBytes', data);
+    logger.debug({
+      tag: 'SYNC-ENGINE',
+      msg: 'Resolved user file size limit from API',
+    });
+
+    return {
+      data,
+    };
+  }
+
+  const lastKnownFileSizeLimit = configStore.get('maxUploadFileSizeInBytes');
+  if (lastKnownFileSizeLimit) {
+    logger.warn({
+      tag: 'SYNC-ENGINE',
+      msg: 'Using stored user file size limit',
+    });
+
+    return { data: lastKnownFileSizeLimit };
+  }
+
+  logger.error({
+    tag: 'SYNC-ENGINE',
+    msg: 'Unable to resolve user file size limit',
+    error,
+  });
+
+  return { error: error || new Error('Unable to resolve user file size limit') };
+}

--- a/src/core/bootstrap/register-session-event-handlers.ts
+++ b/src/core/bootstrap/register-session-event-handlers.ts
@@ -13,6 +13,7 @@ import { getUserAvailableProductsAndStore } from '../../backend/features/payment
 import { registerBackupHandlers } from '../../backend/features/backup/register-backup-handlers';
 import { startBackupsIfAvailable } from '../../backend/features/backup/start-backups-if-available';
 import { stopVirtualDrive } from '../../backend/features/virtual-drive/services/virtual-drive.service';
+import { resolveUserFileSizeLimit } from '../../backend/features/user/file-size-limit/resolve-user-file-size-limit';
 
 function onWidgetIsReady() {
   registerBackupHandlers();
@@ -51,6 +52,7 @@ async function onUserLoggedIn() {
     } else if (widget) {
       widget.show();
     }
+    await resolveUserFileSizeLimit();
     await getUserAvailableProductsAndStore();
     await trySetupAntivirusIpcAndInitialize();
   } catch (error) {

--- a/src/core/electron/store/app-store.interface.ts
+++ b/src/core/electron/store/app-store.interface.ts
@@ -4,7 +4,6 @@ import { Language } from '../../../apps/shared/Locale/Language';
 import { ConfigTheme } from '../../../apps/shared/types/Theme';
 
 type BackupList = Record<string, { enabled: boolean; folderId: number; folderUuid: string }>;
-
 export type SavedConfig = {
   lastOnboardingShown: string;
   backupsEnabled: boolean;
@@ -20,6 +19,7 @@ export type SavedConfig = {
   backupList: BackupList;
   nautilusExtensionVersion: number;
   discoveredBackup: number;
+  maxUploadFileSizeInBytes: number;
 };
 
 export type AppStore = {
@@ -59,4 +59,5 @@ export type AppStore = {
 
   // Drive
   availableUserProducts?: UserAvailableProducts;
+  maxUploadFileSizeInBytes: number;
 };

--- a/src/core/electron/store/defaults.ts
+++ b/src/core/electron/store/defaults.ts
@@ -38,6 +38,7 @@ export const defaults: AppStore = {
 
   // Drive
   availableUserProducts: undefined,
+  maxUploadFileSizeInBytes: 0,
 };
 
 export const fieldsToSave: Array<keyof AppStore> = [
@@ -54,4 +55,5 @@ export const fieldsToSave: Array<keyof AppStore> = [
   'backupList',
   'nautilusExtensionVersion',
   'discoveredBackup',
+  'maxUploadFileSizeInBytes',
 ];

--- a/src/infra/drive-server/out/dto.ts
+++ b/src/infra/drive-server/out/dto.ts
@@ -10,3 +10,5 @@ export type CreateThumbnailDto = components['schemas']['CreateThumbnailDto'];
 export type ThumbnailDto = components['schemas']['ThumbnailDto'];
 
 export type GetFolderContentDto = components['schemas']['GetFolderContentDto'];
+
+export type UserFileSizeLimit = components['schemas']['GetFileLimitsDto']['maxUploadFileSize'];

--- a/src/infra/drive-server/services/files/services/get-user-file-size-limit.test.ts
+++ b/src/infra/drive-server/services/files/services/get-user-file-size-limit.test.ts
@@ -1,0 +1,46 @@
+import { partialSpyOn } from 'tests/vitest/utils.helper';
+
+import { driveServerClient } from '../../../client/drive-server.client.instance';
+import { DriveServerError } from '../../../drive-server.error';
+
+import { getUserFileSizeLimit } from './get-user-file-size-limit';
+
+describe('getUserFileSizeLimit', () => {
+  const driveServerGetMock = partialSpyOn(driveServerClient, 'GET');
+
+  it('should call GET /files/limits', async () => {
+    driveServerGetMock.mockResolvedValue({ data: { maxUploadFileSize: 1024, versioning: {} } } as object);
+
+    await getUserFileSizeLimit();
+
+    expect(driveServerGetMock).toHaveBeenCalledWith('/files/limits');
+  });
+
+  it('should return only maxUploadFileSize when the request is successful', async () => {
+    driveServerGetMock.mockResolvedValue({ data: { maxUploadFileSize: 1024, versioning: {} } } as object);
+
+    const result = await getUserFileSizeLimit();
+
+    expect(result.data).toBe(1024);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('should preserve null maxUploadFileSize from the API response', async () => {
+    driveServerGetMock.mockResolvedValue({ data: { maxUploadFileSize: null, versioning: {} } } as object);
+
+    const result = await getUserFileSizeLimit();
+
+    expect(result.data).toBe(null);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('should return error when the request fails', async () => {
+    const error = new DriveServerError('NETWORK_ERROR', 500);
+    driveServerGetMock.mockResolvedValue({ data: undefined, error } as object);
+
+    const result = await getUserFileSizeLimit();
+
+    expect(result.error).toBe(error);
+    expect(result.data).toBeUndefined();
+  });
+});

--- a/src/infra/drive-server/services/files/services/get-user-file-size-limit.ts
+++ b/src/infra/drive-server/services/files/services/get-user-file-size-limit.ts
@@ -1,0 +1,12 @@
+import { Result } from '../../../../../context/shared/domain/Result';
+import { driveServerClient } from '../../../client/drive-server.client.instance';
+import { DriveServerError } from '../../../drive-server.error';
+import { UserFileSizeLimit } from '../../../out/dto';
+
+export async function getUserFileSizeLimit(): Promise<Result<UserFileSizeLimit, DriveServerError>> {
+  const { data, error } = await driveServerClient.GET('/files/limits');
+
+  if (error) return { error };
+
+  return { data: data.maxUploadFileSize };
+}


### PR DESCRIPTION
## What is Changed / Added
Now, uppon app startup or, when we recieve the PLAN_UPDATED event from the websocket, we will retrieve and store in the configStore the user maxUploadFileSize. If the API request fails, then we rely on the last stored value, if neither values are available, then we go "blind" and we dont pre-validate the users file size and rely on the backend.
