### PR TITLE
Feat/upgrade dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15967,19 +15967,42 @@
       "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
+      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimatch/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/minimist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "node-schedule": "^2.1.0",
         "reflect-metadata": "^0.2.2",
         "typeorm": "^0.3.26",
-        "uuid": "^8.3.2"
+        "uuid": "^11.1.1"
       },
       "devDependencies": {
         "@electron/rebuild": "4.0.4",
@@ -54,7 +54,7 @@
         "@types/react": "^17.0.38",
         "@types/react-dom": "^17.0.11",
         "@types/terser-webpack-plugin": "^5.0.4",
-        "@types/uuid": "^8.3.4",
+        "@types/uuid": "^11.0.0",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "@vitejs/plugin-react": "^4.7.0",
@@ -3588,20 +3588,6 @@
         "uuid": "^11.1.0"
       }
     },
-    "node_modules/@internxt/lib/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/@internxt/scan": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@internxt/scan/-/scan-1.0.7.tgz",
@@ -7046,11 +7032,15 @@
       "license": "MIT"
     },
     "node_modules/@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
+      "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
+      "deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "uuid": "*"
+      }
     },
     "node_modules/@types/verror": {
       "version": "1.10.11",
@@ -20389,6 +20379,17 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/sorted-array-functions": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz",
@@ -22188,19 +22189,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/typeorm/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/typeorm/node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -22456,12 +22444,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -214,6 +214,16 @@
     "typeorm": "^0.3.26",
     "uuid": "^11.1.1"
   },
+  "overrides": {
+    "@typescript-eslint/typescript-estree": {
+      "minimatch": "9.0.6"
+    },
+    "typeorm": {
+      "glob": {
+        "minimatch": "9.0.6"
+      }
+    }
+  },
   "engines": {
     "node": ">=24.0.0 <25.0.0",
     "npm": ">=10.0.0 <11.0.0"

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "@types/react": "^17.0.38",
     "@types/react-dom": "^17.0.11",
     "@types/terser-webpack-plugin": "^5.0.4",
-    "@types/uuid": "^8.3.4",
+    "@types/uuid": "^11.0.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "@vitejs/plugin-react": "^4.7.0",
@@ -212,7 +212,7 @@
     "node-schedule": "^2.1.0",
     "reflect-metadata": "^0.2.2",
     "typeorm": "^0.3.26",
-    "uuid": "^8.3.2"
+    "uuid": "^11.1.1"
   },
   "engines": {
     "node": ">=24.0.0 <25.0.0",


### PR DESCRIPTION
## What is Changed / Added

This PR addresses the Dependabot security alert for `minimatch` by upgrading the vulnerable `9.x` resolution to `9.0.6` or newer through targeted npm overrides.

## Changes

- Added npm `overrides` in `package.json`.
- Scoped the override to the dependency chains that resolve to vulnerable `minimatch` `9.x`.
- Avoided forcing unrelated `minimatch` major versions used by other packages.

## Why this change

Dependabot reported a ReDoS vulnerability affecting `minimatch` versions `>= 9.0.0` and `< 9.0.6`.  
This update ensures the affected branches resolve to a patched version without introducing unnecessary changes to other dependency paths.
