### PR TITLE
Feat/pb 5241 marketing notifications

### DIFF
--- a/src/apps/main/interface.d.ts
+++ b/src/apps/main/interface.d.ts
@@ -15,6 +15,7 @@ import { AbsolutePath } from '../../context/local/localFile/infrastructure/Absol
 import { StoredValues } from './config/service.types';
 import { AppStore } from './config';
 import { ConfigTheme } from '../shared/types/Theme';
+import { UserNotification } from '../../infra/drive-server/out/dto';
 
 /** This interface and declare global will replace the preload.d.ts.
  * The thing is that instead of that, we will gradually will be declaring the interface here as we generate tests
@@ -152,6 +153,7 @@ export interface IElectronAPI {
   getBackupErrorByFolder(folderId: number): Promise<BackupErrorRecord | undefined>;
   getLastBackupHadIssues(): Promise<boolean>;
   onBackupFatalErrorsChanged(fn: (backupErrors: Array<BackupErrorRecord>) => void): () => void;
+  onMarketingNotifications(fn: (notifications: Array<UserNotification>) => void): () => void;
   getBackupFatalErrors(): Promise<Array<BackupErrorRecord>>;
   onBackupProgress(func: (value: number) => void): () => void;
   startRemoteSync(): Promise<void>;

--- a/src/apps/main/preload.d.ts
+++ b/src/apps/main/preload.d.ts
@@ -3,6 +3,7 @@ import { AuthLoginResponseViewModel } from '../../infra/drive-server/services/au
 import { CleanerReport } from '../../backend/features/cleaner/cleaner.types';
 import { BackupErrorRecord } from '../../backend/features/backup/backup.types';
 import type { Device } from '../../backend/features/backup/types/Device';
+import type { UserNotification } from '../../infra/drive-server/out/dto';
 
 declare interface Window {
   electron: {
@@ -163,6 +164,7 @@ declare interface Window {
       discoveredBackups: () => Promise<void>;
     };
     onBackupFailed: (callback: (error: { message: string; cause: string }) => void) => () => void;
+    onMarketingNotifications: (callback: (notifications: Array<UserNotification>) => void) => () => void;
 
     antivirus: {
       isAvailable: () => Promise<boolean>;

--- a/src/apps/main/preload.js
+++ b/src/apps/main/preload.js
@@ -273,7 +273,7 @@ contextBridge.exposeInMainWorld('electron', {
     return () => ipcRenderer.removeListener(eventName, callbackWrapper);
   },
   openUrl: (url) => {
-    ipcRenderer.invoke('open-url', url);
+    return ipcRenderer.invoke('open-url', url);
   },
   getPreferredAppLanguage() {
     return ipcRenderer.invoke('APP:PREFERRED_LANGUAGE');
@@ -290,6 +290,12 @@ contextBridge.exposeInMainWorld('electron', {
   onBackupFailed(callback) {
     ipcRenderer.on('backup-failed', (_, error) => callback(error));
     return () => ipcRenderer.removeListener('backup-failed', callback);
+  },
+  onMarketingNotifications(callback) {
+    const eventName = 'marketing-notifications';
+    const listener = (_, notifications) => callback(notifications);
+    ipcRenderer.on(eventName, listener);
+    return () => ipcRenderer.removeListener(eventName, listener);
   },
   antivirus: {
     /**

--- a/src/apps/renderer/App.tsx
+++ b/src/apps/renderer/App.tsx
@@ -10,6 +10,7 @@ import IssuesPage from './pages/Issues/IssuesPage';
 import Settings from './pages/Settings';
 import Widget from './pages/Widget';
 import { useBackupNotifications } from './hooks/useBackupNotifications';
+import { useMarketingNotifications } from './hooks/useMarketingNotifications';
 import { useTheme } from './hooks/useTheme';
 import i18next from 'i18next';
 import { isLanguage } from '../shared/Locale/Language';
@@ -52,6 +53,7 @@ function Loader() {
 
 export default function App() {
   useBackupNotifications();
+  useMarketingNotifications();
   useTheme();
 
   // Global IPC → i18next bridge for language changes

--- a/src/apps/renderer/hooks/useMarketingNotifications.test.ts
+++ b/src/apps/renderer/hooks/useMarketingNotifications.test.ts
@@ -1,0 +1,105 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useMarketingNotifications } from './useMarketingNotifications';
+
+const notificationInstances: Array<{
+  title: string;
+  options?: NotificationOptions;
+  onclick: ((event: Event) => void) | null;
+}> = [];
+
+const NotificationMock = vi.fn(function NotificationMock(
+  this: { title: string; options?: NotificationOptions; onclick: ((event: Event) => void) | null },
+  title: string,
+  options?: NotificationOptions,
+) {
+  this.title = title;
+  this.options = options;
+  this.onclick = null;
+  notificationInstances.push(this);
+});
+
+const notification = {
+  id: 'notification-id',
+  link: 'https://internxt.com/promo',
+  message: 'Promo message',
+  expiresAt: null,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  isRead: false,
+  deliveredAt: '2024-01-01T00:00:00.000Z',
+  readAt: null,
+};
+
+describe('useMarketingNotifications', () => {
+  beforeEach(() => {
+    notificationInstances.length = 0;
+    vi.mocked(window.electron.onMarketingNotifications).mockReturnValue(vi.fn());
+    vi.mocked(window.electron.openUrl).mockResolvedValue(undefined);
+    vi.stubGlobal('Notification', NotificationMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('should subscribe to marketing notifications and clean up on unmount', () => {
+    const removeListener = vi.fn();
+    vi.mocked(window.electron.onMarketingNotifications).mockReturnValue(removeListener);
+
+    const { unmount } = renderHook(() => useMarketingNotifications());
+
+    expect(window.electron.onMarketingNotifications).toHaveBeenCalledWith(expect.any(Function));
+
+    unmount();
+
+    expect(removeListener).toHaveBeenCalledOnce();
+  });
+
+  it('should show a native notification for each marketing notification', () => {
+    renderHook(() => useMarketingNotifications());
+    const listener = vi.mocked(window.electron.onMarketingNotifications).mock.calls[0][0];
+
+    act(() => {
+      listener([notification]);
+    });
+
+    expect(NotificationMock).toHaveBeenCalledWith(
+      'Internxt Drive',
+      expect.objectContaining({
+        body: 'Promo message',
+        icon: expect.stringContaining('256x256.png'),
+      }),
+    );
+  });
+
+  it('should open the marketing link when the notification is clicked', async () => {
+    renderHook(() => useMarketingNotifications());
+    const listener = vi.mocked(window.electron.onMarketingNotifications).mock.calls[0][0];
+
+    act(() => {
+      listener([notification]);
+    });
+
+    await notificationInstances[0].onclick?.(new Event('click'));
+
+    expect(window.electron.openUrl).toHaveBeenCalledWith('https://internxt.com/promo');
+  });
+
+  it('should not open non-https notification links', async () => {
+    renderHook(() => useMarketingNotifications());
+    const listener = vi.mocked(window.electron.onMarketingNotifications).mock.calls[0][0];
+
+    act(() => {
+      listener([{ ...notification, link: 'internxt://notification/promo' }]);
+    });
+
+    await notificationInstances[0].onclick?.(new Event('click'));
+
+    expect(window.electron.openUrl).not.toHaveBeenCalled();
+    expect(window.electron.logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        msg: '[RENDERER] Error opening marketing notification link',
+        link: 'internxt://notification/promo',
+      }),
+    );
+  });
+});

--- a/src/apps/renderer/hooks/useMarketingNotifications.ts
+++ b/src/apps/renderer/hooks/useMarketingNotifications.ts
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+import appIcon from '../../../../assets/icons/256x256.png';
+import type { UserNotification } from '../../../infra/drive-server/out/dto';
+
+export function useMarketingNotifications() {
+  useEffect(() => {
+    const removeListener = window.electron.onMarketingNotifications((notifications) => {
+      for (const notification of notifications) {
+        showMarketingNotification(notification);
+      }
+    });
+
+    return () => {
+      removeListener();
+    };
+  }, []);
+}
+
+function showMarketingNotification(notification: UserNotification) {
+  const popup = new Notification('Internxt Drive', {
+    body: notification.message,
+    icon: appIcon,
+  });
+
+  popup.onclick = () => {
+    void openNotificationLink(notification.link);
+  };
+}
+
+async function openNotificationLink(link: string): Promise<void> {
+  try {
+    const url = new URL(link);
+
+    if (url.protocol !== 'https:') {
+      throw new Error('Unsupported marketing notification link protocol: ' + url.protocol);
+    }
+
+    await window.electron.openUrl(url.toString());
+  } catch (error) {
+    window.electron.logger.error({ msg: '[RENDERER] Error opening marketing notification link', link, error });
+  }
+}

--- a/src/backend/features/marketing/index.ts
+++ b/src/backend/features/marketing/index.ts
@@ -1,0 +1,1 @@
+export { showMarketingNotifications } from './notifications/show-marketing-notifications';

--- a/src/backend/features/marketing/notifications/show-marketing-notifications.test.ts
+++ b/src/backend/features/marketing/notifications/show-marketing-notifications.test.ts
@@ -1,0 +1,204 @@
+import { logger } from '@internxt/drive-desktop-core/build/backend';
+import { Notification, shell } from 'electron';
+import { getNotifications } from '../../../../infra/drive-server/services/notifications/get-notifications';
+import { showMarketingNotifications } from './show-marketing-notifications';
+
+vi.mock('../../../../infra/drive-server/services/notifications/get-notifications', () => ({
+  getNotifications: vi.fn(),
+}));
+
+const { notificationInstances } = vi.hoisted(() => ({
+  notificationInstances: [] as Array<{
+    options: Electron.NotificationConstructorOptions;
+    on: ReturnType<typeof vi.fn>;
+    show: ReturnType<typeof vi.fn>;
+  }>,
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => '/tmp/internxt-test'),
+    isPackaged: false,
+  },
+  Notification: Object.assign(
+    vi.fn((options: Electron.NotificationConstructorOptions) => {
+      const instance = {
+        options,
+        on: vi.fn(),
+        show: vi.fn(),
+      };
+      notificationInstances.push(instance);
+      return instance;
+    }),
+    {
+      isSupported: vi.fn(() => true),
+    },
+  ),
+  shell: {
+    openExternal: vi.fn(),
+  },
+}));
+
+describe('showMarketingNotifications', () => {
+  const getNotificationsMock = vi.mocked(getNotifications);
+  const NotificationMock = vi.mocked(Notification);
+  const isSupportedMock = vi.mocked(Notification.isSupported);
+  const openExternalMock = vi.mocked(shell.openExternal);
+
+  beforeEach(() => {
+    notificationInstances.length = 0;
+    isSupportedMock.mockReturnValue(true);
+  });
+
+  it('should show one native notification for each marketing notification', async () => {
+    getNotificationsMock.mockResolvedValue({
+      data: [
+        {
+          id: 'first-notification',
+          link: 'https://internxt.com/first',
+          message: 'First message',
+          expiresAt: null,
+          createdAt: '2024-01-01T00:00:00.000Z',
+          isRead: false,
+          deliveredAt: '2024-01-01T00:00:00.000Z',
+          readAt: null,
+        },
+        {
+          id: 'second-notification',
+          link: 'https://internxt.com/second',
+          message: 'Second message',
+          expiresAt: null,
+          createdAt: '2024-01-01T00:00:00.000Z',
+          isRead: false,
+          deliveredAt: '2024-01-01T00:00:00.000Z',
+          readAt: null,
+        },
+      ],
+    });
+
+    await showMarketingNotifications();
+
+    expect(NotificationMock).toHaveBeenCalledTimes(2);
+    expect(notificationInstances[0].options).toMatchObject({
+      title: 'Internxt Drive',
+      body: 'First message',
+      icon: expect.stringContaining('icons/256x256.png'),
+    });
+    expect(notificationInstances[1].options.body).toBe('Second message');
+    expect(notificationInstances[0].show).toHaveBeenCalledOnce();
+    expect(notificationInstances[1].show).toHaveBeenCalledOnce();
+  });
+
+  it('should open the notification link when the native notification is clicked', async () => {
+    getNotificationsMock.mockResolvedValue({
+      data: [
+        {
+          id: 'notification-id',
+          link: 'https://internxt.com/promo',
+          message: 'Promo message',
+          expiresAt: null,
+          createdAt: '2024-01-01T00:00:00.000Z',
+          isRead: false,
+          deliveredAt: '2024-01-01T00:00:00.000Z',
+          readAt: null,
+        },
+      ],
+    });
+
+    await showMarketingNotifications();
+    const clickHandler = notificationInstances[0].on.mock.calls.find(([event]) => event === 'click')?.[1];
+    await clickHandler();
+
+    expect(openExternalMock).toHaveBeenCalledWith('https://internxt.com/promo');
+  });
+
+  it('should not open non-https notification links', async () => {
+    getNotificationsMock.mockResolvedValue({
+      data: [
+        {
+          id: 'notification-id',
+          link: 'internxt://notification/promo',
+          message: 'Promo message',
+          expiresAt: null,
+          createdAt: '2024-01-01T00:00:00.000Z',
+          isRead: false,
+          deliveredAt: '2024-01-01T00:00:00.000Z',
+          readAt: null,
+        },
+      ],
+    });
+
+    await showMarketingNotifications();
+    const clickHandler = notificationInstances[0].on.mock.calls.find(([event]) => event === 'click')?.[1];
+    await clickHandler();
+
+    expect(openExternalMock).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        msg: 'Error opening marketing notification link',
+        link: 'internxt://notification/promo',
+      }),
+    );
+  });
+
+  it('should log native notification failures', async () => {
+    getNotificationsMock.mockResolvedValue({
+      data: [
+        {
+          id: 'notification-id',
+          link: 'https://internxt.com/promo',
+          message: 'Promo message',
+          expiresAt: null,
+          createdAt: '2024-01-01T00:00:00.000Z',
+          isRead: false,
+          deliveredAt: '2024-01-01T00:00:00.000Z',
+          readAt: null,
+        },
+      ],
+    });
+    const error = new Error('Notification failed');
+
+    await showMarketingNotifications();
+    const failedHandler = notificationInstances[0].on.mock.calls.find(([event]) => event === 'failed')?.[1];
+    failedHandler(error);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        msg: 'Marketing notification failed',
+        error,
+      }),
+    );
+  });
+
+  it('should not create native notifications when they are not supported', async () => {
+    isSupportedMock.mockReturnValue(false);
+    getNotificationsMock.mockResolvedValue({
+      data: [
+        {
+          id: 'notification-id',
+          link: 'https://internxt.com/promo',
+          message: 'Promo message',
+          expiresAt: null,
+          createdAt: '2024-01-01T00:00:00.000Z',
+          isRead: false,
+          deliveredAt: '2024-01-01T00:00:00.000Z',
+          readAt: null,
+        },
+      ],
+    });
+
+    await showMarketingNotifications();
+
+    expect(NotificationMock).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith({ msg: 'Native notifications are not supported' });
+  });
+
+  it('should log when fetching marketing notifications fails', async () => {
+    const error = new Error('Request failed');
+    getNotificationsMock.mockResolvedValue({ error });
+
+    await showMarketingNotifications();
+
+    expect(logger.error).toHaveBeenCalledWith({ msg: 'Error showing marketing notifications', error });
+  });
+});

--- a/src/backend/features/marketing/notifications/show-marketing-notifications.test.ts
+++ b/src/backend/features/marketing/notifications/show-marketing-notifications.test.ts
@@ -1,5 +1,5 @@
 import { logger } from '@internxt/drive-desktop-core/build/backend';
-import { Notification, shell } from 'electron';
+import { broadcastToWindows } from '../../../../apps/main/windows';
 import { getNotifications } from '../../../../infra/drive-server/services/notifications/get-notifications';
 import { showMarketingNotifications } from './show-marketing-notifications';
 
@@ -7,190 +7,50 @@ vi.mock('../../../../infra/drive-server/services/notifications/get-notifications
   getNotifications: vi.fn(),
 }));
 
-const { notificationInstances } = vi.hoisted(() => ({
-  notificationInstances: [] as Array<{
-    options: Electron.NotificationConstructorOptions;
-    on: ReturnType<typeof vi.fn>;
-    show: ReturnType<typeof vi.fn>;
-  }>,
-}));
-
-vi.mock('electron', () => ({
-  app: {
-    getPath: vi.fn(() => '/tmp/internxt-test'),
-    isPackaged: false,
-  },
-  Notification: Object.assign(
-    vi.fn((options: Electron.NotificationConstructorOptions) => {
-      const instance = {
-        options,
-        on: vi.fn(),
-        show: vi.fn(),
-      };
-      notificationInstances.push(instance);
-      return instance;
-    }),
-    {
-      isSupported: vi.fn(() => true),
-    },
-  ),
-  shell: {
-    openExternal: vi.fn(),
-  },
+vi.mock('../../../../apps/main/windows', () => ({
+  broadcastToWindows: vi.fn(),
 }));
 
 describe('showMarketingNotifications', () => {
   const getNotificationsMock = vi.mocked(getNotifications);
-  const NotificationMock = vi.mocked(Notification);
-  const isSupportedMock = vi.mocked(Notification.isSupported);
-  const openExternalMock = vi.mocked(shell.openExternal);
+  const broadcastToWindowsMock = vi.mocked(broadcastToWindows);
 
-  beforeEach(() => {
-    notificationInstances.length = 0;
-    isSupportedMock.mockReturnValue(true);
-  });
-
-  it('should show one native notification for each marketing notification', async () => {
-    getNotificationsMock.mockResolvedValue({
-      data: [
-        {
-          id: 'first-notification',
-          link: 'https://internxt.com/first',
-          message: 'First message',
-          expiresAt: null,
-          createdAt: '2024-01-01T00:00:00.000Z',
-          isRead: false,
-          deliveredAt: '2024-01-01T00:00:00.000Z',
-          readAt: null,
-        },
-        {
-          id: 'second-notification',
-          link: 'https://internxt.com/second',
-          message: 'Second message',
-          expiresAt: null,
-          createdAt: '2024-01-01T00:00:00.000Z',
-          isRead: false,
-          deliveredAt: '2024-01-01T00:00:00.000Z',
-          readAt: null,
-        },
-      ],
-    });
+  it('should broadcast marketing notifications to renderer windows', async () => {
+    const notifications = [
+      {
+        id: 'first-notification',
+        link: 'https://internxt.com/first',
+        message: 'First message',
+        expiresAt: null,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        isRead: false,
+        deliveredAt: '2024-01-01T00:00:00.000Z',
+        readAt: null,
+      },
+      {
+        id: 'second-notification',
+        link: 'https://internxt.com/second',
+        message: 'Second message',
+        expiresAt: null,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        isRead: false,
+        deliveredAt: '2024-01-01T00:00:00.000Z',
+        readAt: null,
+      },
+    ];
+    getNotificationsMock.mockResolvedValue({ data: notifications });
 
     await showMarketingNotifications();
 
-    expect(NotificationMock).toHaveBeenCalledTimes(2);
-    expect(notificationInstances[0].options).toMatchObject({
-      title: 'Internxt Drive',
-      body: 'First message',
-      icon: expect.stringContaining('icons/256x256.png'),
-    });
-    expect(notificationInstances[1].options.body).toBe('Second message');
-    expect(notificationInstances[0].show).toHaveBeenCalledOnce();
-    expect(notificationInstances[1].show).toHaveBeenCalledOnce();
+    expect(broadcastToWindowsMock).toHaveBeenCalledWith('marketing-notifications', notifications);
   });
 
-  it('should open the notification link when the native notification is clicked', async () => {
-    getNotificationsMock.mockResolvedValue({
-      data: [
-        {
-          id: 'notification-id',
-          link: 'https://internxt.com/promo',
-          message: 'Promo message',
-          expiresAt: null,
-          createdAt: '2024-01-01T00:00:00.000Z',
-          isRead: false,
-          deliveredAt: '2024-01-01T00:00:00.000Z',
-          readAt: null,
-        },
-      ],
-    });
-
-    await showMarketingNotifications();
-    const clickHandler = notificationInstances[0].on.mock.calls.find(([event]) => event === 'click')?.[1];
-    await clickHandler();
-
-    expect(openExternalMock).toHaveBeenCalledWith('https://internxt.com/promo');
-  });
-
-  it('should not open non-https notification links', async () => {
-    getNotificationsMock.mockResolvedValue({
-      data: [
-        {
-          id: 'notification-id',
-          link: 'internxt://notification/promo',
-          message: 'Promo message',
-          expiresAt: null,
-          createdAt: '2024-01-01T00:00:00.000Z',
-          isRead: false,
-          deliveredAt: '2024-01-01T00:00:00.000Z',
-          readAt: null,
-        },
-      ],
-    });
-
-    await showMarketingNotifications();
-    const clickHandler = notificationInstances[0].on.mock.calls.find(([event]) => event === 'click')?.[1];
-    await clickHandler();
-
-    expect(openExternalMock).not.toHaveBeenCalled();
-    expect(logger.error).toHaveBeenCalledWith(
-      expect.objectContaining({
-        msg: 'Error opening marketing notification link',
-        link: 'internxt://notification/promo',
-      }),
-    );
-  });
-
-  it('should log native notification failures', async () => {
-    getNotificationsMock.mockResolvedValue({
-      data: [
-        {
-          id: 'notification-id',
-          link: 'https://internxt.com/promo',
-          message: 'Promo message',
-          expiresAt: null,
-          createdAt: '2024-01-01T00:00:00.000Z',
-          isRead: false,
-          deliveredAt: '2024-01-01T00:00:00.000Z',
-          readAt: null,
-        },
-      ],
-    });
-    const error = new Error('Notification failed');
-
-    await showMarketingNotifications();
-    const failedHandler = notificationInstances[0].on.mock.calls.find(([event]) => event === 'failed')?.[1];
-    failedHandler(error);
-
-    expect(logger.error).toHaveBeenCalledWith(
-      expect.objectContaining({
-        msg: 'Marketing notification failed',
-        error,
-      }),
-    );
-  });
-
-  it('should not create native notifications when they are not supported', async () => {
-    isSupportedMock.mockReturnValue(false);
-    getNotificationsMock.mockResolvedValue({
-      data: [
-        {
-          id: 'notification-id',
-          link: 'https://internxt.com/promo',
-          message: 'Promo message',
-          expiresAt: null,
-          createdAt: '2024-01-01T00:00:00.000Z',
-          isRead: false,
-          deliveredAt: '2024-01-01T00:00:00.000Z',
-          readAt: null,
-        },
-      ],
-    });
+  it('should not broadcast when there are no marketing notifications', async () => {
+    getNotificationsMock.mockResolvedValue({ data: [] });
 
     await showMarketingNotifications();
 
-    expect(NotificationMock).not.toHaveBeenCalled();
-    expect(logger.warn).toHaveBeenCalledWith({ msg: 'Native notifications are not supported' });
+    expect(broadcastToWindowsMock).not.toHaveBeenCalled();
   });
 
   it('should log when fetching marketing notifications fails', async () => {

--- a/src/backend/features/marketing/notifications/show-marketing-notifications.ts
+++ b/src/backend/features/marketing/notifications/show-marketing-notifications.ts
@@ -1,0 +1,57 @@
+import path from 'node:path';
+import { Notification, shell } from 'electron';
+import { logger } from '@internxt/drive-desktop-core/build/backend';
+import { foldResult } from '../../../../context/shared/domain/Result';
+import { PATHS } from '../../../../core/electron/paths';
+import { getNotifications } from '../../../../infra/drive-server/services/notifications/get-notifications';
+import type { UserNotification } from '../../../../infra/drive-server/out/dto';
+
+const NOTIFICATION_ICON_PATH = path.join(PATHS.RESOURCES_PATH, 'icons', '256x256.png');
+
+export async function showMarketingNotifications() {
+  const result = await getNotifications();
+
+  foldResult(result, {
+    data: showNotifications,
+    error: (error) => logger.error({ msg: 'Error showing marketing notifications', error }),
+  });
+}
+
+function showNotifications(notifications: Array<UserNotification>) {
+  if (!Notification.isSupported()) {
+    logger.warn({ msg: 'Native notifications are not supported' });
+    return;
+  }
+
+  for (const notification of notifications) {
+    const popup = new Notification({
+      title: 'Internxt Drive',
+      body: notification.message,
+      icon: NOTIFICATION_ICON_PATH,
+    });
+
+    popup.on('click', async () => {
+      try {
+        await openNotificationLink(notification.link);
+      } catch (error) {
+        logger.error({ msg: 'Error opening marketing notification link', link: notification.link, error });
+      }
+    });
+
+    popup.on('failed', (error) => {
+      logger.error({ msg: 'Marketing notification failed', notification, error });
+    });
+
+    popup.show();
+  }
+}
+
+async function openNotificationLink(link: string): Promise<void> {
+  const url = new URL(link);
+
+  if (url.protocol !== 'https:') {
+    throw new Error('Unsupported marketing notification link protocol: ' + url.protocol);
+  }
+
+  await shell.openExternal(url.toString());
+}

--- a/src/backend/features/marketing/notifications/show-marketing-notifications.ts
+++ b/src/backend/features/marketing/notifications/show-marketing-notifications.ts
@@ -1,12 +1,10 @@
-import path from 'node:path';
-import { Notification, shell } from 'electron';
 import { logger } from '@internxt/drive-desktop-core/build/backend';
+import { broadcastToWindows } from '../../../../apps/main/windows';
 import { foldResult } from '../../../../context/shared/domain/Result';
-import { PATHS } from '../../../../core/electron/paths';
 import { getNotifications } from '../../../../infra/drive-server/services/notifications/get-notifications';
 import type { UserNotification } from '../../../../infra/drive-server/out/dto';
 
-const NOTIFICATION_ICON_PATH = path.join(PATHS.RESOURCES_PATH, 'icons', '256x256.png');
+const MARKETING_NOTIFICATIONS_EVENT = 'marketing-notifications';
 
 export async function showMarketingNotifications() {
   const result = await getNotifications();
@@ -18,40 +16,10 @@ export async function showMarketingNotifications() {
 }
 
 function showNotifications(notifications: Array<UserNotification>) {
-  if (!Notification.isSupported()) {
-    logger.warn({ msg: 'Native notifications are not supported' });
+  if (notifications.length === 0) {
     return;
   }
 
-  for (const notification of notifications) {
-    const popup = new Notification({
-      title: 'Internxt Drive',
-      body: notification.message,
-      icon: NOTIFICATION_ICON_PATH,
-    });
-
-    popup.on('click', async () => {
-      try {
-        await openNotificationLink(notification.link);
-      } catch (error) {
-        logger.error({ msg: 'Error opening marketing notification link', link: notification.link, error });
-      }
-    });
-
-    popup.on('failed', (error) => {
-      logger.error({ msg: 'Marketing notification failed', notification, error });
-    });
-
-    popup.show();
-  }
-}
-
-async function openNotificationLink(link: string): Promise<void> {
-  const url = new URL(link);
-
-  if (url.protocol !== 'https:') {
-    throw new Error('Unsupported marketing notification link protocol: ' + url.protocol);
-  }
-
-  await shell.openExternal(url.toString());
+  logger.debug({ msg: 'Forward marketing notifications to renderer', count: notifications.length });
+  broadcastToWindows(MARKETING_NOTIFICATIONS_EVENT, notifications);
 }

--- a/src/context/shared/domain/Result.ts
+++ b/src/context/shared/domain/Result.ts
@@ -10,6 +10,6 @@ export function foldResult<T, E extends Error, R>(
   return isError(result) ? cases.error(result.error) : cases.data(result.data);
 }
 
-function isError<T, E extends Error>(result: Result<T, E>): result is { error: E; data?: undefined } {
+function isError<T, E extends Error>(result: Result<T, E>): result is { error: E } {
   return result.error !== undefined;
 }

--- a/src/context/shared/domain/Result.ts
+++ b/src/context/shared/domain/Result.ts
@@ -1,1 +1,15 @@
 export type Result<T, E extends Error = Error> = { data: T; error?: undefined } | { error: E; data?: undefined };
+
+export function foldResult<T, E extends Error, R>(
+  result: Result<T, E>,
+  cases: {
+    data: (data: T) => R;
+    error: (error: E) => R;
+  },
+): R {
+  return isError(result) ? cases.error(result.error) : cases.data(result.data);
+}
+
+function isError<T, E extends Error>(result: Result<T, E>): result is { error: E; data?: undefined } {
+  return result.error !== undefined;
+}

--- a/src/core/bootstrap/register-session-event-handlers.ts
+++ b/src/core/bootstrap/register-session-event-handlers.ts
@@ -14,6 +14,7 @@ import { registerBackupHandlers } from '../../backend/features/backup/register-b
 import { startBackupsIfAvailable } from '../../backend/features/backup/start-backups-if-available';
 import { stopVirtualDrive } from '../../backend/features/virtual-drive/services/virtual-drive.service';
 import { resolveUserFileSizeLimit } from '../../backend/features/user/file-size-limit/resolve-user-file-size-limit';
+import { showMarketingNotifications } from '../../backend/features/marketing';
 
 function onWidgetIsReady() {
   registerBackupHandlers();
@@ -55,6 +56,7 @@ async function onUserLoggedIn() {
     await resolveUserFileSizeLimit();
     await getUserAvailableProductsAndStore();
     await trySetupAntivirusIpcAndInitialize();
+    void showMarketingNotifications();
   } catch (error) {
     logger.error({
       msg: 'Error on main process while handling USER_LOGGED_IN event:',

--- a/src/infra/drive-server/out/dto.ts
+++ b/src/infra/drive-server/out/dto.ts
@@ -11,3 +11,4 @@ export type ThumbnailDto = components['schemas']['ThumbnailDto'];
 export type GetFolderContentDto = components['schemas']['GetFolderContentDto'];
 
 export type UserFileSizeLimit = components['schemas']['GetFileLimitsDto']['maxUploadFileSize'];
+export type UserNotification = components['schemas']['NotificationWithStatusDto'];

--- a/src/infra/drive-server/services/notifications/get-notifications.test.ts
+++ b/src/infra/drive-server/services/notifications/get-notifications.test.ts
@@ -1,0 +1,38 @@
+import { partialSpyOn } from 'tests/vitest/utils.helper';
+import { driveServerClient } from '../../client/drive-server.client.instance';
+import { DriveServerError } from '../../drive-server.error';
+import { getNotifications } from './get-notifications';
+
+describe('getNotifications', () => {
+  const driveServerGetMock = partialSpyOn(driveServerClient, 'GET');
+
+  it('should fetch user notifications', async () => {
+    const notifications = [
+      {
+        id: 'notification-id',
+        link: 'https://internxt.com/promotions/black-friday',
+        message: 'Black Friday Sale - 50% off all plans!',
+        expiresAt: null,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        isRead: false,
+        deliveredAt: '2024-01-01T00:00:00.000Z',
+        readAt: null,
+      },
+    ];
+    driveServerGetMock.mockResolvedValue({ data: notifications } as object);
+
+    const result = await getNotifications();
+
+    expect(driveServerGetMock).toHaveBeenCalledWith('/notifications');
+    expect(result).toStrictEqual({ data: notifications });
+  });
+
+  it('should return the drive server error when the request fails', async () => {
+    const error = new DriveServerError('UNKNOWN', 500);
+    driveServerGetMock.mockResolvedValue({ error } as object);
+
+    const result = await getNotifications();
+
+    expect(result).toStrictEqual({ error });
+  });
+});

--- a/src/infra/drive-server/services/notifications/get-notifications.ts
+++ b/src/infra/drive-server/services/notifications/get-notifications.ts
@@ -1,0 +1,8 @@
+import { Result } from '../../../../context/shared/domain/Result';
+import { driveServerClient } from '../../client/drive-server.client.instance';
+import { DriveServerError } from '../../drive-server.error';
+import { UserNotification } from '../../out/dto';
+
+export async function getNotifications(): Promise<Result<Array<UserNotification>, DriveServerError>> {
+  return await driveServerClient.GET('/notifications');
+}


### PR DESCRIPTION
## What is Changed / Added

This pull request introduces the feature of recieving Marketing notifications, once the user clicks the notification it will redirect to the given url.
also Added `foldResult` to the shared Result utility to make success/error handling explicit.
Initially, showing notifications through main process was giving me a "SIGSEV" error and crashing the app so i have made a workaround to open them from the renderer process.

----
## Why

Marketing notifications need to be shown as native user notifications and open their associated marketing URL when clicked.

The first main-process implementation could trigger an Electron native SIGSEGV on Linux when clicking notifications. Moving the clickable notification behavior to the renderer avoids that crash path and reuses the existing renderer notification/open-url pattern already used elsewhere in the app.

