### PR TITLE
Fix/app packaging

### DIFF
--- a/.erb/configs/webpack.config.base.ts
+++ b/.erb/configs/webpack.config.base.ts
@@ -5,13 +5,9 @@
 import webpack from 'webpack';
 import webpackPaths from './webpack.paths';
 
-// Only packages that were in release/app/package.json should be external
-// These are native modules or runtime dependencies that cannot/should not be bundled
-const nativeExternals = [
-  'better-sqlite3',
-  'reflect-metadata',
-  'typeorm',
-];
+// Keep JS deps bundled, but leave native modules as externals.
+// better-sqlite3 relies on runtime native loading (bindings), which breaks when bundled.
+const nativeExternals = ['better-sqlite3'];
 
 const configuration: webpack.Configuration = {
   externals: nativeExternals,

--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
     "appId": "com.internxt.drive",
     "asar": true,
     "asarUnpack": [
-      "**\\*.{node,dll}",
+      "**/*.{node,dll}",
+      "**/node_modules/better-sqlite3/**",
+      "**/node_modules/bindings/**",
       "**/node_modules/sharp/**"
     ],
     "files": [
@@ -90,7 +92,28 @@
       "./assets/**",
       "./clamAV/**",
       "./src/apps/nautilus-extension/internxt-virtual-drive.py",
-      "./dist/fuse-daemon"
+      "./dist/fuse-daemon",
+      {
+        "from": "./node_modules/better-sqlite3",
+        "to": "node_modules/better-sqlite3",
+        "filter": [
+          "**/*"
+        ]
+      },
+      {
+        "from": "./node_modules/bindings",
+        "to": "node_modules/bindings",
+        "filter": [
+          "**/*"
+        ]
+      },
+      {
+        "from": "./node_modules/file-uri-to-path",
+        "to": "node_modules/file-uri-to-path",
+        "filter": [
+          "**/*"
+        ]
+      }
     ]
   },
   "devDependencies": {

--- a/src/apps/drive/hydration-api/HydrationApi.test.ts
+++ b/src/apps/drive/hydration-api/HydrationApi.test.ts
@@ -93,7 +93,9 @@ describe('HydrationApi', () => {
 
       const middlewareCandidates = appUseMock.mock.calls.flatMap((args) => args as unknown[]);
       const debugMiddlewareCandidate = middlewareCandidates.find(
-        (arg) => typeof arg === 'function' && (arg as Function).length === 3,
+        (arg) =>
+          typeof arg === 'function' &&
+          (arg as (req: express.Request, res: express.Response, next: express.NextFunction) => void).length === 3,
       );
       const debugMiddleware = debugMiddlewareCandidate as express.RequestHandler | undefined;
 

--- a/src/apps/drive/hydration-api/HydrationApi.test.ts
+++ b/src/apps/drive/hydration-api/HydrationApi.test.ts
@@ -5,6 +5,7 @@ import * as filesRoute from './routes/files';
 import { partialSpyOn } from 'tests/vitest/utils.helper';
 import express from 'express';
 import { loggerMock } from 'tests/vitest/mocks.helper';
+import { Server } from 'http';
 
 const buildHydrationRouterMock = partialSpyOn(contentsRoute, 'buildHydrationRouter');
 const buildFilesRouterMock = partialSpyOn(filesRoute, 'buildFilesRouter');
@@ -18,46 +19,98 @@ function createMockContainer() {
 describe('HydrationApi', () => {
   let container: Container;
   let hydrationApi: HydrationApi;
+  let connectionHandler: ((socket: import('node:net').Socket) => void) | null;
+
+  function mockServerListen(api: HydrationApi) {
+    const closeMock = vi.fn((callback?: (error?: Error) => void) => {
+      callback?.();
+    });
+
+    const server = {
+      on: vi.fn((event: string, handler: (socket: import('node:net').Socket) => void) => {
+        if (event === 'connection') {
+          connectionHandler = handler;
+        }
+
+        return server;
+      }),
+      close: closeMock,
+    } as unknown as Server;
+
+    const app = (api as unknown as { app: express.Express }).app;
+    vi.spyOn(app, 'listen').mockImplementation((_port: number, callback?: () => void) => {
+      callback?.();
+      return server;
+    });
+
+    return { closeMock };
+  }
 
   beforeEach(() => {
     container = createMockContainer();
+    connectionHandler = null;
 
     buildHydrationRouterMock.mockReturnValue(express.Router());
     buildFilesRouterMock.mockReturnValue(express.Router());
   });
 
   afterEach(async () => {
-    await hydrationApi.stop();
+    if (hydrationApi) {
+      await hydrationApi.stop();
+    }
   });
 
   describe('start', () => {
     it('should start the server and log the port', async () => {
       hydrationApi = new HydrationApi(container);
+      mockServerListen(hydrationApi);
 
       await hydrationApi.start({ debug: false, timeElapsed: false });
 
-      expect(loggerMock.debug).toBeCalledWith({
+      expect(loggerMock.debug).toHaveBeenCalledWith({
         msg: '[HYDRATION API] running on port 4567',
       });
     });
 
     it('should build hydration and files routers with the container', async () => {
       hydrationApi = new HydrationApi(container);
+      mockServerListen(hydrationApi);
 
       await hydrationApi.start({ debug: false, timeElapsed: false });
 
-      expect(buildHydrationRouterMock).toBeCalledWith(container);
-      expect(buildFilesRouterMock).toBeCalledWith(container);
+      expect(buildHydrationRouterMock).toHaveBeenCalledWith(container);
+      expect(buildFilesRouterMock).toHaveBeenCalledWith(container);
     });
 
     it('should enable debug logging middleware when debug is true', async () => {
       hydrationApi = new HydrationApi(container);
+      mockServerListen(hydrationApi);
+
+      const app = (hydrationApi as unknown as { app: express.Express }).app;
+      const appUseMock = vi.spyOn(app, 'use');
 
       await hydrationApi.start({ debug: true, timeElapsed: false });
 
-      await fetch('http://localhost:4567/hydration/test');
-      // The request itself may 404, but the debug middleware should have logged
-      expect(loggerMock.debug).toBeCalledWith(
+      const middlewareCandidates = appUseMock.mock.calls.flatMap((args) => args as unknown[]);
+      const debugMiddlewareCandidate = middlewareCandidates.find(
+        (arg) => typeof arg === 'function' && (arg as Function).length === 3,
+      );
+      const debugMiddleware = debugMiddlewareCandidate as express.RequestHandler | undefined;
+
+      expect(debugMiddleware).toBeDefined();
+
+      const next = vi.fn();
+      debugMiddleware?.(
+        {
+          method: 'GET',
+          url: '/hydration/test',
+        } as express.Request,
+        {} as express.Response,
+        next,
+      );
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(loggerMock.debug).toHaveBeenCalledWith(
         expect.objectContaining({
           msg: expect.stringContaining('[HYDRATION API]'),
         }),
@@ -74,6 +127,7 @@ describe('HydrationApi', () => {
 
     it('should stop the server after it was started', async () => {
       hydrationApi = new HydrationApi(container);
+      mockServerListen(hydrationApi);
       await hydrationApi.start({ debug: false, timeElapsed: false });
 
       await expect(hydrationApi.stop()).resolves.toBeUndefined();
@@ -81,27 +135,29 @@ describe('HydrationApi', () => {
 
     it('should destroy open sockets when stopping', async () => {
       hydrationApi = new HydrationApi(container);
+      mockServerListen(hydrationApi);
       await hydrationApi.start({ debug: false, timeElapsed: false });
 
-      // Create a connection to generate an open socket
-      const socket = new (await import('node:net')).Socket();
-      await new Promise<void>((resolve, reject) => {
-        socket.connect(4567, '127.0.0.1', () => resolve());
-        socket.on('error', reject);
-      });
+      const socket = {
+        destroy: vi.fn(),
+        once: vi.fn(),
+      } as unknown as import('node:net').Socket;
 
-      // Small delay to ensure the server registers the socket
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(connectionHandler).toBeDefined();
+      connectionHandler?.(socket);
 
       await expect(hydrationApi.stop()).resolves.toBeUndefined();
+      expect(socket.destroy).toHaveBeenCalledTimes(1);
     });
 
     it('should be safe to call stop multiple times', async () => {
       hydrationApi = new HydrationApi(container);
+      const { closeMock } = mockServerListen(hydrationApi);
       await hydrationApi.start({ debug: false, timeElapsed: false });
 
       await hydrationApi.stop();
       await expect(hydrationApi.stop()).resolves.toBeUndefined();
+      expect(closeMock).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/apps/main/auth/get-credentials.test.ts
+++ b/src/apps/main/auth/get-credentials.test.ts
@@ -1,14 +1,13 @@
 import { safeStorage } from 'electron';
-import { logger } from '@internxt/drive-desktop-core/build/backend';
 import { getCredentials } from './get-credentials';
 import ConfigStore, { AppStore } from '../config';
 import { calls, call, partialSpyOn } from 'tests/vitest/utils.helper';
+import { loggerMock } from 'tests/vitest/mocks.helper';
 
 describe('getCredentials', () => {
   const configGetMock = partialSpyOn(ConfigStore, 'get');
   const safeStorageIsAvailableMock = partialSpyOn(safeStorage, 'isEncryptionAvailable');
   const safeStorageDecryptMock = partialSpyOn(safeStorage, 'decryptString');
-  const loggerErrorMock = partialSpyOn(logger, 'error');
 
   const plainToken = 'plain-token-123';
   const plainMnemonic = 'plain mnemonic words here';
@@ -120,7 +119,7 @@ describe('getCredentials', () => {
   });
 
   describe('when safeStorage is not available', () => {
-    it('should return plaintext values and log error', () => {
+    it('should return empty values and log warning', () => {
       configGetMock.mockImplementation((key: keyof AppStore) => {
         const values: Record<string, unknown> = {
           newToken: encryptedToken,
@@ -136,11 +135,11 @@ describe('getCredentials', () => {
       const result = getCredentials();
 
       expect(result).toMatchObject({
-        newToken: encryptedToken,
-        mnemonic: encryptedMnemonic,
+        newToken: '',
+        mnemonic: '',
       });
-      call(loggerErrorMock).toMatchObject({
-        msg: '[AUTH] Safe Storage was not available when decrypting encrypted token',
+      call(loggerMock.warn).toMatchObject({
+        msg: '[AUTH] Safe Storage was not available when decrypting encrypted token, falling back to logged-out state',
         tag: 'AUTH',
       });
       calls(safeStorageDecryptMock).toHaveLength(0);
@@ -148,7 +147,7 @@ describe('getCredentials', () => {
   });
 
   describe('when decryption fails', () => {
-    it('should throw error and log it', () => {
+    it('should return empty values and log warning', () => {
       configGetMock.mockImplementation((key: keyof AppStore) => {
         const values: Record<string, unknown> = {
           newToken: encryptedToken,
@@ -165,9 +164,14 @@ describe('getCredentials', () => {
         throw decryptError;
       });
 
-      expect(() => getCredentials()).toThrow();
-      call(loggerErrorMock).toMatchObject({
-        msg: '[AUTH] Failed to decrypt token',
+      const result = getCredentials();
+
+      expect(result).toMatchObject({
+        newToken: '',
+        mnemonic: '',
+      });
+      call(loggerMock.debug).toMatchObject({
+        msg: '[AUTH] Failed to decrypt token, falling back to logged-out state',
         tag: 'AUTH',
         error: decryptError,
       });

--- a/src/apps/main/auth/get-credentials.ts
+++ b/src/apps/main/auth/get-credentials.ts
@@ -4,6 +4,10 @@ import ConfigStore from '../config';
 
 const TOKEN_ENCODING = 'latin1';
 
+function emptyCredentials() {
+  return { newToken: '', mnemonic: '' };
+}
+
 export function getCredentials() {
   const newToken = ConfigStore.get('newToken');
   const mnemonic = ConfigStore.get('mnemonic');
@@ -16,11 +20,11 @@ export function getCredentials() {
 
   try {
     if (!safeStorage.isEncryptionAvailable()) {
-      logger.error({
-        msg: '[AUTH] Safe Storage was not available when decrypting encrypted token',
+      logger.warn({
+        msg: '[AUTH] Safe Storage was not available when decrypting encrypted token, falling back to logged-out state',
         tag: 'AUTH',
       });
-      return { newToken, mnemonic };
+      return emptyCredentials();
     }
 
     const decryptedToken = tokenEncrypted ? safeStorage.decryptString(Buffer.from(newToken, TOKEN_ENCODING)) : newToken;
@@ -34,10 +38,12 @@ export function getCredentials() {
       mnemonic: decryptedMnemonic,
     };
   } catch (err) {
-    throw logger.error({
-      msg: '[AUTH] Failed to decrypt token',
+    logger.debug({
+      msg: '[AUTH] Failed to decrypt token, falling back to logged-out state',
       tag: 'AUTH',
       error: err,
     });
+
+    return emptyCredentials();
   }
 }

--- a/src/apps/main/database/collections/DriveFileCollection.ts
+++ b/src/apps/main/database/collections/DriveFileCollection.ts
@@ -5,7 +5,7 @@ import { Repository } from 'typeorm';
 import { logger } from '@internxt/drive-desktop-core/build/backend';
 
 export class DriveFilesCollection implements DatabaseCollectionAdapter<DriveFile> {
-  private repository: Repository<DriveFile> = AppDataSource.getRepository('drive_file');
+  private repository: Repository<DriveFile> = AppDataSource.getRepository(DriveFile);
 
   async connect(): Promise<{ success: boolean }> {
     return {

--- a/src/apps/main/database/collections/DriveFolderCollection.ts
+++ b/src/apps/main/database/collections/DriveFolderCollection.ts
@@ -5,7 +5,7 @@ import { Repository } from 'typeorm';
 import { logger } from '@internxt/drive-desktop-core/build/backend';
 
 export class DriveFoldersCollection implements DatabaseCollectionAdapter<DriveFolder> {
-  private repository: Repository<DriveFolder> = AppDataSource.getRepository('drive_folder');
+  private repository: Repository<DriveFolder> = AppDataSource.getRepository(DriveFolder);
   async connect(): Promise<{ success: boolean }> {
     return {
       success: true,


### PR DESCRIPTION
## What is Changed / Added
----
- Packaging and bundling strategy was adjusted to treat only the native runtime dependency as external.
- Build packaging rules were expanded to explicitly include native runtime modules and their transitive runtime helpers inside the final app artifact.
- Authentication credential recovery was hardened:
  - Added a shared empty-credentials fallback helper.
  - Replaced failure behavior from throwing to graceful fallback when secure storage is unavailable or decryption fails.
  - Updated logging levels/messages to reflect controlled fallback behavior.
- Database repository initialization was corrected to use entity-class repository resolution instead of string-based names.
- Hydration API tests were refactored to remove network-dependent behavior:
  - Server startup is now mocked.
  - Socket lifecycle and idempotent shutdown behavior are now verified with deterministic unit-level mocks.
  - Debug middleware behavior is asserted directly through middleware invocation.
- Main-process authentication tests were aligned with the new fallback contract and updated expected logs.

## Why
- Native module loading requires filesystem/runtime resolution patterns that break when fully bundled, so native dependencies must remain external while keeping pure JS dependencies bundled for stability and smaller integration risk.
- Explicitly copying native runtime modules ensures they are always present in packaged builds, preventing runtime crashes caused by missing binary or helper modules.
- Auth token decryption is a startup-critical path; failing closed into a logged-out state is safer and more resilient than throwing, because it avoids hard startup failures and preserves a recoverable user flow.
- Logging changes distinguish expected degraded-mode behavior from fatal errors, reducing false-positive error noise and improving operational diagnostics.
- Entity-based repository resolution avoids fragile string mapping issues and makes ORM metadata resolution more robust during runtime initialization.
- Network-free unit tests are faster, less flaky, and deterministic in CI; mocking server internals validates the same behavior without relying on local ports/timing.
- Updated tests lock in the new resilience contract so regressions (re-throwing decrypt errors, non-idempotent stop behavior, socket cleanup gaps) are detected early.