### PR TITLE
fix: handle empty backup files without fileId in downloads and improv…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internxt",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "author": "Internxt <hello@internxt.com>",
   "description": "Internxt Drive client UI",
   "main": "./dist/main/main.js",

--- a/src/apps/main/network/download.test.ts
+++ b/src/apps/main/network/download.test.ts
@@ -1,0 +1,145 @@
+import type { WriteStream } from 'fs';
+import { call } from '../../../../tests/vitest/utils.helper';
+
+const {
+  addFileMock,
+  addFolderMock,
+  closeMock,
+  createWriteStreamMock,
+  downloadFileV2Mock,
+  getBackupFolderTreeSnapshotMock,
+} = vi.hoisted(() => {
+  return {
+    addFileMock: vi.fn(),
+    addFolderMock: vi.fn(),
+    closeMock: vi.fn().mockResolvedValue(undefined),
+    createWriteStreamMock: vi.fn(),
+    downloadFileV2Mock: vi.fn(),
+    getBackupFolderTreeSnapshotMock: vi.fn(),
+  };
+});
+
+vi.mock('fs', () => {
+  return {
+    default: {
+      createWriteStream: createWriteStreamMock,
+    },
+    createWriteStream: createWriteStreamMock,
+  };
+});
+
+vi.mock('./zip.service', () => {
+  class FlatFolderZip {
+    constructor() {
+      // noop
+    }
+
+    addFile(name: string, source: ReadableStream<Uint8Array>) {
+      addFileMock(name, source);
+    }
+
+    addFolder(name: string) {
+      addFolderMock(name);
+    }
+
+    async close() {
+      return closeMock();
+    }
+  }
+
+  return { FlatFolderZip };
+});
+
+vi.mock('./downloadv2', () => {
+  return {
+    default: downloadFileV2Mock,
+  };
+});
+
+vi.mock('@internxt/lib', () => {
+  return {
+    items: {
+      getItemDisplayName: ({ name }: { name: string }) => name,
+    },
+  };
+});
+
+vi.mock('../../../backend/features/backup/get-backup-folder-tree-snapshot', () => {
+  return {
+    getBackupFolderTreeSnapshot: getBackupFolderTreeSnapshotMock,
+  };
+});
+
+import { downloadFolderAsZip } from './download';
+
+describe('download', () => {
+  beforeEach(() => {
+    const fakeWriteStream = {
+      write: (_chunk: Buffer, cb?: (error?: Error | null) => void) => cb?.(null),
+      end: (cb?: (error?: Error | null) => void) => cb?.(null),
+      destroy: vi.fn(),
+    } as unknown as WriteStream;
+
+    createWriteStreamMock.mockReturnValue(fakeWriteStream);
+    downloadFileV2Mock.mockClear();
+    addFileMock.mockClear();
+    addFolderMock.mockClear();
+    closeMock.mockClear();
+  });
+
+  it('should add empty file to zip without remote download when backup file has no fileId', async () => {
+    getBackupFolderTreeSnapshotMock.mockResolvedValue({
+      data: {
+        tree: {
+          id: 11,
+          plainName: 'root',
+          files: [
+            {
+              id: 77,
+              type: '',
+              bucket: 'bucket-id',
+              fileId: null,
+              size: '0',
+            },
+          ],
+          children: [],
+        },
+        folderDecryptedNames: {
+          11: 'Ubuntu',
+        },
+        fileDecryptedNames: {
+          77: 'empty.txt',
+        },
+        size: 0,
+      },
+    });
+
+    await downloadFolderAsZip(
+      'Ubuntu',
+      'https://gateway.internxt.com',
+      'folder-uuid',
+      '/tmp/backup.zip',
+      {
+        bridgeUser: 'bridge-user',
+        bridgePass: 'bridge-pass',
+        encryptionKey: 'mnemonic',
+      },
+      {},
+    );
+
+    expect(downloadFileV2Mock).not.toHaveBeenCalled();
+    call(addFolderMock).toBe('Ubuntu');
+    expect(addFileMock).toHaveBeenCalledTimes(1);
+
+    const addFileCall = addFileMock.mock.calls[0] as [string, ReadableStream<Uint8Array>];
+    const fileName = addFileCall[0];
+    const source = addFileCall[1];
+    expect(fileName).toBe('Ubuntu/empty.txt');
+    expect(source).toBeInstanceOf(ReadableStream);
+
+    const reader = source.getReader();
+    const firstRead = await reader.read();
+
+    expect(firstRead.done).toBe(true);
+  });
+});

--- a/src/apps/main/network/download.ts
+++ b/src/apps/main/network/download.ts
@@ -42,6 +42,20 @@ export interface IDownloadParams {
   };
 }
 
+function createEmptyReadableStream() {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.close();
+    },
+  });
+}
+
+function isEmptyBackupFileWithoutFileId(file: { size: number | string; fileId: string | null }) {
+  const fileSize = typeof file.size === 'string' ? Number(file.size) : file.size;
+
+  return fileSize === 0 && !file.fileId;
+}
+
 function convertToWritableStream(writeStream: fs.WriteStream): WritableStream<Uint8Array> {
   return new WritableStream<Uint8Array>({
     async write(chunk) {
@@ -322,10 +336,23 @@ export async function downloadFolderAsZip(
         type: file.type,
       });
 
+      if (isEmptyBackupFileWithoutFileId(file)) {
+        logger.warn({
+          tag: 'BACKUPS',
+          msg: 'Skipping remote fetch for empty backup file without fileId',
+          fileId: file.fileId,
+          bucketId: file.bucket,
+          fileName: displayFilename,
+        });
+
+        zip.addFile(folderPath + '/' + displayFilename, createEmptyReadableStream());
+        continue;
+      }
+
       const fileStreamPromise = downloadFile({
         networkApiUrl,
         bucketId: file.bucket,
-        fileId: file.fileId,
+        fileId: file.fileId ?? '',
         creds: {
           pass: bridgePass,
           user: bridgeUser,

--- a/src/apps/main/network/zip.service.test.ts
+++ b/src/apps/main/network/zip.service.test.ts
@@ -1,0 +1,35 @@
+import { unzipSync } from 'fflate';
+import { WritableStream } from 'node:stream/web';
+import { FlatFolderZip } from './zip.service';
+
+describe('zip.service', () => {
+  it('should create a valid zip when adding an empty file', async () => {
+    const chunks: Buffer[] = [];
+
+    const destination = new WritableStream<Uint8Array>({
+      write(chunk) {
+        chunks.push(Buffer.from(chunk));
+      },
+    });
+
+    const zip = new FlatFolderZip(destination, {});
+
+    zip.addFolder('Ubuntu');
+    zip.addFile(
+      'Ubuntu/empty.txt',
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.close();
+        },
+      }),
+    );
+
+    await zip.close();
+
+    const zipBuffer = Buffer.concat(chunks);
+    const extracted = unzipSync(zipBuffer);
+
+    expect(Object.keys(extracted)).toStrictEqual(['Ubuntu/', 'Ubuntu/empty.txt']);
+    expect(Buffer.from(extracted['Ubuntu/empty.txt'])).toHaveLength(0);
+  });
+});

--- a/src/apps/main/network/zip.service.ts
+++ b/src/apps/main/network/zip.service.ts
@@ -7,7 +7,7 @@ type FlatFolderZipOpts = {
   progress?: (loadedBytes: number) => void;
 };
 
-type AddFileToZipFunction = (name: string, source: ReadableStream<Uint8Array>) => void;
+type AddFileToZipFunction = (name: string, source: ReadableStream<Uint8Array>) => Promise<void>;
 
 type AddFolderToZipFunction = (name: string) => void;
 
@@ -21,6 +21,7 @@ export interface ZipStream {
 export function createFolderWithFilesWritable(progress?: FlatFolderZipOpts['progress']): ZipStream {
   const zip = new Zip();
   let passthroughController: ReadableStreamDefaultController<Uint8Array> | null = null;
+  const pendingFiles = new Set<Promise<void>>();
 
   const passthrough = new ReadableStream<Uint8Array>({
     start(controller) {
@@ -58,27 +59,35 @@ export function createFolderWithFilesWritable(progress?: FlatFolderZipOpts['prog
 
   // todo: abort with .terminate()
   return {
-    addFile: (name: string, source: ReadableStream<Uint8Array>): void => {
+    addFile: (name: string, source: ReadableStream<Uint8Array>) => {
       const writer = new AsyncZipDeflate(name, {
         level: 0,
       });
 
       zip.add(writer);
 
-      source.pipeTo(
-        new WritableStream({
-          write(chunk) {
-            processedSize += chunk.length;
+      const pendingFile = source
+        .pipeTo(
+          new WritableStream({
+            write(chunk) {
+              processedSize += chunk.length;
 
-            progress?.(processedSize);
+              progress?.(processedSize);
 
-            writer.push(chunk, false);
-          },
-          close() {
-            writer.push(new Uint8Array(0), true);
-          },
-        }),
-      );
+              writer.push(chunk, false);
+            },
+            close() {
+              writer.push(new Uint8Array(0), true);
+            },
+          }),
+        )
+        .finally(() => {
+          pendingFiles.delete(pendingFile);
+        });
+
+      pendingFiles.add(pendingFile);
+
+      return pendingFile;
     },
     addFolder: (name: string): void => {
       const writer = new AsyncZipDeflate(name + '/', {
@@ -88,7 +97,8 @@ export function createFolderWithFilesWritable(progress?: FlatFolderZipOpts['prog
       writer.push(new Uint8Array(0), true);
     },
     stream: passthrough,
-    end: () => {
+    end: async () => {
+      await Promise.all(pendingFiles);
       zip.end();
     },
   };
@@ -114,7 +124,7 @@ export class FlatFolderZip {
   addFile(name: string, source: ReadableStream<Uint8Array>): void {
     if (this.abortController?.signal.aborted) return;
 
-    this.zip.addFile(name, source);
+    void this.zip.addFile(name, source);
   }
 
   addFolder(name: string): void {
@@ -126,7 +136,7 @@ export class FlatFolderZip {
   async close(): Promise<void> {
     if (this.abortController?.signal.aborted) return;
 
-    this.zip.end();
+    await this.zip.end();
 
     await this.finished;
   }

--- a/src/apps/main/network/zip.service.ts
+++ b/src/apps/main/network/zip.service.ts
@@ -136,7 +136,7 @@ export class FlatFolderZip {
   async close(): Promise<void> {
     if (this.abortController?.signal.aborted) return;
 
-    await this.zip.end();
+    this.zip.end();
 
     await this.finished;
   }

--- a/src/apps/main/platform/handlers.ts
+++ b/src/apps/main/platform/handlers.ts
@@ -1,12 +1,5 @@
-import { ipcMain } from 'electron';
-import { exec } from 'child_process';
+import { ipcMain, shell } from 'electron';
 
 ipcMain.handle('open-url', (_, url: string) => {
-  return new Promise<void>((resolve, reject) => {
-    exec(`xdg-open ${url} &`, (error) => {
-      if (error) reject(error);
-
-      resolve();
-    });
-  });
+  return shell.openExternal(url);
 });


### PR DESCRIPTION
## What is Changed / Added
- Fixed backup download flow for zero-byte files that have no server fileId.
- Added guard to skip useless remote download request when file is empty and fileId is missing.
- Added local empty file entry to ZIP so backup stays complete.
- Fixed ZIP writer lifecycle to wait for all pending file streams before closing archive.
- Added tests for:
  - empty backup file without fileId path
  - ZIP validity when adding an empty file
- Updated external URL open handler to use Electron shell API instead of spawning a shell command.

----
## Why
- Some backups include zero-byte files with no S3 object and no fileId.
- Old flow still tried remote fetch and failed with 400 (malformed file id), breaking full backup download.
- Initial fix skipped request, but exposed ZIP close race and extraction error.
- New ZIP synchronization ensures archive is finalized only after all file streams are finished, including empty files.
- Result: backup download no longer fails on empty files, and generated ZIP extracts correctly.