### PR TITLE
feat: skip upload and backup for zero-byte files and update validation logic

### DIFF
--- a/src/backend/features/backup/upload/update-file-to-backup.test.ts
+++ b/src/backend/features/backup/upload/update-file-to-backup.test.ts
@@ -59,6 +59,15 @@ describe('update-file-to-backup', () => {
     });
   });
 
+  it('should skip file update when file size is zero', async () => {
+    const result = await updateFileToBackup({ ...baseParams, size: 0, signal: abortController.signal });
+
+    expect(result).toStrictEqual({ data: undefined });
+    expect(uploadContentMock).not.toHaveBeenCalled();
+    expect(overrideFileMock).not.toHaveBeenCalled();
+    expect(addMaxFileSizeRejectionMock).not.toHaveBeenCalled();
+  });
+
   it('should return ABORTED error when signal is already aborted', async () => {
     abortController.abort();
 

--- a/src/backend/features/backup/upload/update-file-to-backup.ts
+++ b/src/backend/features/backup/upload/update-file-to-backup.ts
@@ -8,6 +8,7 @@ import { overrideFileToBackend } from './override-file-to-backend';
 import configStore from '../../../../apps/main/config';
 import { addMaxFileSizeRejection } from '../../user/file-size-limit/add-max-file-size-rejection';
 import { validateUploadFileSize } from '../../user/file-size-limit/validate-upload-file-size';
+import { logger } from '@internxt/drive-desktop-core/build/backend';
 
 export type UpdateFileParams = {
   path: string;
@@ -22,9 +23,20 @@ async function updateFile(file: UpdateFileParams): Promise<Result<void, DriveDes
   const validation = validateUploadFileSize({
     size: file.size,
     maxUploadFileSize: configStore.get('maxUploadFileSizeInBytes'),
+    allowEmptyFile: false,
   });
 
   if (!validation.allowed) {
+    if (validation.reason === 'EMPTY_FILE') {
+      logger.warn({
+        tag: 'BACKUPS',
+        msg: 'Skipping backup file update because it is empty',
+        path: file.path,
+        size: file.size,
+      });
+      return { data: undefined };
+    }
+
     addMaxFileSizeRejection({ path: file.path, fileSize: file.size, validation, blockUploadPath: false });
     return { data: undefined };
   }

--- a/src/backend/features/backup/upload/upload-file-to-backup.test.ts
+++ b/src/backend/features/backup/upload/upload-file-to-backup.test.ts
@@ -62,6 +62,15 @@ describe('upload-file-to-backup', () => {
     });
   });
 
+  it('should skip file upload when file size is zero', async () => {
+    const result = await uploadFileToBackup({ ...baseParams, size: 0, signal: abortController.signal });
+
+    expect(result).toStrictEqual({ data: null });
+    expect(uploadContentMock).not.toHaveBeenCalled();
+    expect(createFileToBackendMock).not.toHaveBeenCalled();
+    expect(addMaxFileSizeRejectionMock).not.toHaveBeenCalled();
+  });
+
   it('should return error when content upload fails with a non-retryable error', async () => {
     const uploadError = new DriveDesktopError('UNKNOWN', 'Upload failed');
     uploadContentMock.mockResolvedValue({ error: uploadError });

--- a/src/backend/features/backup/upload/upload-file-to-backup.ts
+++ b/src/backend/features/backup/upload/upload-file-to-backup.ts
@@ -26,9 +26,20 @@ async function uploadFile(file: UploadFileParams): Promise<Result<File | null, D
   const validation = validateUploadFileSize({
     size: file.size,
     maxUploadFileSize: configStore.get('maxUploadFileSizeInBytes'),
+    allowEmptyFile: false,
   });
 
   if (!validation.allowed) {
+    if (validation.reason === 'EMPTY_FILE') {
+      logger.warn({
+        tag: 'BACKUPS',
+        msg: 'Skipping backup file because it is empty',
+        path: file.path,
+        size: file.size,
+      });
+      return { data: null };
+    }
+
     addMaxFileSizeRejection({ path: file.path, fileSize: file.size, validation, blockUploadPath: false });
     logger.warn({
       tag: 'BACKUPS',

--- a/src/backend/features/user/file-size-limit/validate-upload-file-size.test.ts
+++ b/src/backend/features/user/file-size-limit/validate-upload-file-size.test.ts
@@ -41,4 +41,13 @@ describe('validateUploadFileSize', () => {
   it('should ignore zero-byte files', () => {
     expect(validateUploadFileSize({ size: 0, maxUploadFileSize: 100 })).toStrictEqual({ allowed: true });
   });
+
+  it('should reject zero-byte files when empty files are not allowed', () => {
+    expect(validateUploadFileSize({ size: 0, maxUploadFileSize: 100, allowEmptyFile: false })).toStrictEqual({
+      allowed: false,
+      reason: 'EMPTY_FILE',
+      maxFileSize: 0,
+      showUpgradeCta: false,
+    });
+  });
 });

--- a/src/backend/features/user/file-size-limit/validate-upload-file-size.ts
+++ b/src/backend/features/user/file-size-limit/validate-upload-file-size.ts
@@ -4,7 +4,7 @@ export type UploadFileSizeValidation =
   | { allowed: true }
   | {
       allowed: false;
-      reason: 'PLAN_LIMIT_EXCEEDED' | 'ABSOLUTE_CAP_EXCEEDED';
+      reason: 'EMPTY_FILE' | 'PLAN_LIMIT_EXCEEDED' | 'ABSOLUTE_CAP_EXCEEDED';
       maxFileSize: number;
       showUpgradeCta: boolean;
     };
@@ -12,9 +12,23 @@ export type UploadFileSizeValidation =
 type Props = {
   size: number;
   maxUploadFileSize?: number | null;
+  allowEmptyFile?: boolean;
 };
 
-export function validateUploadFileSize({ size, maxUploadFileSize }: Props): UploadFileSizeValidation {
+export function validateUploadFileSize({
+  size,
+  maxUploadFileSize,
+  allowEmptyFile = true,
+}: Props): UploadFileSizeValidation {
+  if (!allowEmptyFile && size <= 0) {
+    return {
+      allowed: false,
+      reason: 'EMPTY_FILE',
+      maxFileSize: 0,
+      showUpgradeCta: false,
+    };
+  }
+
   if (size > ABSOLUTE_UPLOAD_FILE_SIZE_LIMIT) {
     return {
       allowed: false,


### PR DESCRIPTION
## What is Changed / Added
----
- I added a centralized empty-file validation rule in the upload size validator, with an opt-in flag so existing flows keep their current behavior unless they explicitly disable empty files.
- I introduced a new EMPTY_FILE validation reason and used it in backup upload/update flows only, so zero-byte files are skipped before any content upload attempt.
- I updated backup upload logic to short-circuit cleanly for empty files, avoiding both content upload and metadata creation for new backup entries.
- I updated backup update logic to short-circuit cleanly for empty files as well, avoiding unnecessary override calls for existing entries.
- I kept max-size rejection behavior unchanged for real size-limit cases, and made sure empty-file skips do not trigger max-size rejection tracking/modal behavior.

## Why
- We were seeing inconsistent failures when the client tried to upload zero-byte files during backup (for example, server 500 in some environments and Invalid size in others).
- Even though the backup could continue for other files, these attempts generated noisy error logs and, in some cases, unnecessary retry behavior.
- By handling zero-byte files earlier and consistently, we prevent avoidable upload calls, reduce retry/log noise, and make backup behavior more predictable.
- Centralizing this in the validator keeps the rule in one place and avoids duplicating ad-hoc checks across multiple upload paths.