### PR TITLE
fix: update token scheduler to use dynamic expiration and renewal intervals

### DIFF
--- a/src/apps/main/auth/refresh-token/create-token-schedule-with-retry.ts
+++ b/src/apps/main/auth/refresh-token/create-token-schedule-with-retry.ts
@@ -5,10 +5,13 @@ import { logger } from '@internxt/drive-desktop-core/build/backend';
 import { refreshToken } from './refresh-token';
 
 const CREATE_SCHEDULE_RETRY_LIMIT = 3;
+const TOKEN_EXPIRATION_HOURS = 12;
+const TOKEN_RENEW_INTERVAL_HOURS = 4;
+const TOKEN_RENEW_BEFORE_EXPIRATION_DAYS = (TOKEN_EXPIRATION_HOURS - TOKEN_RENEW_INTERVAL_HOURS) / 24;
 
 export async function createTokenScheduleWithRetry() {
   const { newToken } = getCredentials();
-  const tokenScheduler = new TokenScheduler(5, newToken, closeUserSession);
+  const tokenScheduler = new TokenScheduler(TOKEN_RENEW_BEFORE_EXPIRATION_DAYS, newToken, closeUserSession);
 
   let attempt = 0;
   while (attempt < CREATE_SCHEDULE_RETRY_LIMIT) {


### PR DESCRIPTION
## What is Changed / Added

- Updated token renewal policy from a fixed 5-day value to the new timing policy.
- Added explicit constants for:
  - Token expiration: 12 hours
  - Renewal interval: 4 hours
  - Renewal offset before expiration: 8 hours (12h - 4h), converted to days for the current scheduler input