### PR TITLE
feat: Add documentation for prerequisites and implement smoke tests for file system extension

### DIFF
--- a/.github/workflows/file-manager-extension-smoke.yml
+++ b/.github/workflows/file-manager-extension-smoke.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install base dependencies
         run: |
           apt-get update
-          DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl git python3 xdg-utils
+          DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl git python3 unzip xdg-utils
 
       - name: Check out Git repository
         uses: actions/checkout@v4

--- a/.github/workflows/file-manager-extension-smoke.yml
+++ b/.github/workflows/file-manager-extension-smoke.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
+      - name: Ensure Electron install
+        run: node ./.erb/scripts/ensure-electron-install.cjs
+
       - name: Run extension smoke test
         env:
           EXPECTED_FILE_MANAGER: ${{ matrix.fileManager }}

--- a/.github/workflows/file-manager-extension-smoke.yml
+++ b/.github/workflows/file-manager-extension-smoke.yml
@@ -1,0 +1,61 @@
+name: File Manager Extension Smoke
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  smoke-file-manager-extension:
+    name: "🧪 Smoke ${{ matrix.fileManager }} extension"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        fileManager: [nautilus, nemo, dolphin]
+
+    container:
+      image: ubuntu:24.04
+
+    steps:
+      - name: Install base dependencies
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl git python3 xdg-utils
+
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install file manager for matrix target
+        run: |
+          case "${{ matrix.fileManager }}" in
+            nautilus)
+              DEBIAN_FRONTEND=noninteractive apt-get install -y nautilus
+              ;;
+            nemo)
+              DEBIAN_FRONTEND=noninteractive apt-get install -y nemo
+              ;;
+            dolphin)
+              DEBIAN_FRONTEND=noninteractive apt-get install -y dolphin
+              ;;
+            *)
+              echo "Unsupported file manager: ${{ matrix.fileManager }}"
+              exit 1
+              ;;
+          esac
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run extension smoke test
+        env:
+          EXPECTED_FILE_MANAGER: ${{ matrix.fileManager }}
+          HOME: /tmp/internxt-home
+        run: |
+          mkdir -p "$HOME"
+          npm run smoke:file-manager-extension

--- a/.github/workflows/file-manager-extension-smoke.yml
+++ b/.github/workflows/file-manager-extension-smoke.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run extension smoke test
         env:
           EXPECTED_FILE_MANAGER: ${{ matrix.fileManager }}
-          HOME: /tmp/internxt-home
+          HOME: ${{ github.workspace }}/.tmp/internxt-home
         run: |
           mkdir -p "$HOME"
           npm run smoke:file-manager-extension

--- a/README.md
+++ b/README.md
@@ -22,26 +22,61 @@ sudo dpkg -i internxt_2.6.0_amd64.deb
 
 ## Prerequisites
 
-Our system requires the key manager to be properly configured. On KDE-based distributions, this configuration often needs to be done manually before using the application.
+### KDE Wallet Configuration Guide
 
-### Step 1: Install Kleopatra
+Our application requires the KDE key manager to be properly configured. Depending on your security needs, you can choose between two methods:
+
+* **Method 1 (Recommended / Easy):** Uses standard symmetric encryption with a master password. It is fast, requires no additional software, and supports **automatic unlocking when you log in**.
+* **Method 2 (Advanced / GPG):** Uses an OpenPGP key pair via Kleopatra for higher security, though it requires manual entry of your passphrase or PIN upon logging in.
+
+> **Why Kleopatra?** > It is the official KDE key manager, offering native integration with KDE Wallet, fewer permission conflicts, and a user-friendly setup wizard compared to generic GPG tools.
+
+---
+
+### Method 1: Standard Setup (Easy & Recommended)
+
+This is the simplest way to set up KDE Wallet and allows seamless automatic unlocking upon system login.
+
+#### Step 1: Open KDE Wallet Settings
+1. Open **System Settings**.
+2. Navigate to **KDE Wallet** (or search for *Wallet* in the search bar).
+3. Ensure **Enable the KDE wallet subsystem** is checked.
+
+#### Step 2: Create a New Wallet
+1. Under **Automatic Wallet Selection**, click **Create New Wallet...**
+2. Enter a name for your wallet (e.g., `kdewallet`).
+3. Select **Blowfish encryption** (standard password) and click **Next**.
+4. Enter and confirm your **Master Password**. 
+   > **Note:** If you set this password to match your Linux user login password, the wallet will unlock automatically when you sign in!
+5. Click **Finish**.
+
+---
+
+### Method 2: GPG Key Setup (Advanced)
+
+Use this method if you prefer asymmetric GPG encryption managed via external key managers.
+
+#### Step 1: Install Kleopatra
 Install **Kleopatra**, which will be used to generate your GPG encryption key:
 
-`sudo apt update && sudo apt install kleopatra`
+```bash
+sudo apt update && sudo apt install kleopatra
+```
 
-### Step 2: Generate a GPG Key Pair
+#### Step 2: Generate a GPG Key Pair
 1. Open **Kleopatra** and click **New Key Pair** (or **File > New Key Pair**).
 2. Select **Create a personal OpenPGP key pair**.
 3. Enter your **Name** and **Email Address**.
 4. Click **Create** (or **Finish**) to complete the setup.
 
-### Step 3: Configure KDE Wallet
+### Step 3: Configure KDE Wallet for GPG
 1. Open **System Settings** and search for **KDE Wallet**.
 2. Under **Automatic Wallet Selection**, click **Create New Wallet...**
 3. Select **Use GPG encryption for added security** and click **Next**.
 4. Choose the GPG key you created earlier in Kleopatra and click **Finish**.
 
 ---
+
 *You're all set! You can now use the application as expected.*
 
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,31 @@ Download and install the `.deb` package for full compatibility:
 sudo dpkg -i internxt_2.6.0_amd64.deb
 ```
 
+## Prerequisites
+
+Our system requires the key manager to be properly configured. On KDE-based distributions, this configuration often needs to be done manually before using the application.
+
+### Step 1: Install Kleopatra
+Install **Kleopatra**, which will be used to generate your GPG encryption key:
+
+`sudo apt update && sudo apt install kleopatra`
+
+### Step 2: Generate a GPG Key Pair
+1. Open **Kleopatra** and click **New Key Pair** (or **File > New Key Pair**).
+2. Select **Create a personal OpenPGP key pair**.
+3. Enter your **Name** and **Email Address**.
+4. Click **Create** (or **Finish**) to complete the setup.
+
+### Step 3: Configure KDE Wallet
+1. Open **System Settings** and search for **KDE Wallet**.
+2. Under **Automatic Wallet Selection**, click **Create New Wallet...**
+3. Select **Use GPG encryption for added security** and click **Next**.
+4. Choose the GPG key you created earlier in Kleopatra and click **Finish**.
+
+---
+*You're all set! You can now use the application as expected.*
+
+
 ### AppImage
 
 Alternatively, you can use the AppImage format:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Our application requires the KDE key manager to be properly configured. Dependin
 * **Method 1 (Recommended / Easy):** Uses standard symmetric encryption with a master password. It is fast, requires no additional software, and supports **automatic unlocking when you log in**.
 * **Method 2 (Advanced / GPG):** Uses an OpenPGP key pair via Kleopatra for higher security, though it requires manual entry of your passphrase or PIN upon logging in.
 
-> **Why Kleopatra?** > It is the official KDE key manager, offering native integration with KDE Wallet, fewer permission conflicts, and a user-friendly setup wizard compared to generic GPG tools.
+> **Why Kleopatra?** It is the official KDE key manager, offering native integration with KDE Wallet, fewer permission conflicts, and a user-friendly setup wizard compared to generic GPG tools.
+>
+> For reference, Electron's secure storage API is documented here: [safe-storage](https://www.electronjs.org/docs/latest/api/safe-storage).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 
 ## Compatibility
 
-As of right now, Internxt Drive Desktop for Linux is only compatible with Ubuntu and Debian with the File explorer **Nautilus** (The default file explorer for Gnome).
+Internxt Drive Desktop for Linux is currently tested and supported on Ubuntu and Debian with the file managers **Nautilus**, **Nemo**, and **Dolphin**.
 
-We cannot guarantee that the app will work properly on other Linux distributions or with other file explorers as our development and testing efforts are focused on ensuring the best experience for Ubuntu and Debian users.
+The application is also available through the **.deb** and **.rpm** packages for these distributions.
+
+We cannot guarantee full compatibility on other Linux distributions or with unsupported file managers, although the app may still work in some environments.
 
 ## Installation
 
@@ -76,8 +78,6 @@ sudo apt update && sudo apt install kleopatra
 4. Choose the GPG key you created earlier in Kleopatra and click **Finish**.
 
 ---
-
-*You're all set! You can now use the application as expected.*
 
 
 ### AppImage

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Download and install the `.deb` package for full compatibility:
 sudo dpkg -i internxt_2.6.0_amd64.deb
 ```
 
-## Prerequisites
+## Prerequisites for KDE based distros
 
 ### KDE Wallet Configuration Guide
 
@@ -48,7 +48,7 @@ This is the simplest way to set up KDE Wallet and allows seamless automatic unlo
 1. Under **Automatic Wallet Selection**, click **Create New Wallet...**
 2. Enter a name for your wallet (e.g., `kdewallet`).
 3. Select **Blowfish encryption** (standard password) and click **Next**.
-4. Enter and confirm your **Master Password**. 
+4. Enter and confirm your **Master Password**.
    > **Note:** If you set this password to match your Linux user login password, the wallet will unlock automatically when you sign in!
 5. Click **Finish**.
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:renderer": "vitest --config vitest.config.renderer.ts",
     "test:renderer:coverage": "vitest --config vitest.config.renderer.ts --coverage",
     "test:coverage": "concurrently \"npm:test:main:coverage\" \"npm:test:renderer:coverage\"",
+    "smoke:file-manager-extension": "NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true ts-node src/backend/features/file-manager-extension/file-manager-extension-smoke.ts",
     "coverage:merge": "lcov-result-merger 'coverage/*/lcov.info' 'coverage/lcov.info'",
     "type-check": "./scripts/tsc-max-errors.sh",
     "prepare": "husky install",

--- a/src/backend/features/file-manager-extension/constants.ts
+++ b/src/backend/features/file-manager-extension/constants.ts
@@ -1,0 +1,12 @@
+const supportedFileManagers = [
+  'nautilus',
+  'nemo',
+  'dolphin',
+] as const;
+type SupportedFileManager = (typeof supportedFileManagers)[number];
+
+export function isSupportedFileManager(
+  value: string,
+): value is SupportedFileManager {
+  return (supportedFileManagers as readonly string[]).includes(value);
+}

--- a/src/backend/features/file-manager-extension/constants.ts
+++ b/src/backend/features/file-manager-extension/constants.ts
@@ -1,12 +1,6 @@
-const supportedFileManagers = [
-  'nautilus',
-  'nemo',
-  'dolphin',
-] as const;
+const supportedFileManagers = ['nautilus', 'nemo', 'dolphin'] as const;
 type SupportedFileManager = (typeof supportedFileManagers)[number];
 
-export function isSupportedFileManager(
-  value: string,
-): value is SupportedFileManager {
+export function isSupportedFileManager(value: string): value is SupportedFileManager {
   return (supportedFileManagers as readonly string[]).includes(value);
 }

--- a/src/backend/features/file-manager-extension/constants.ts
+++ b/src/backend/features/file-manager-extension/constants.ts
@@ -2,5 +2,5 @@ const supportedFileManagers = ['nautilus', 'nemo', 'dolphin'] as const;
 type SupportedFileManager = (typeof supportedFileManagers)[number];
 
 export function isSupportedFileManager(value: string): value is SupportedFileManager {
-  return (supportedFileManagers as readonly string[]).includes(value);
+  return supportedFileManagers.some((sfm) => sfm === value);
 }

--- a/src/backend/features/file-manager-extension/file-manager-extension-smoke.ts
+++ b/src/backend/features/file-manager-extension/file-manager-extension-smoke.ts
@@ -4,6 +4,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { copyExtensionFile, deleteExtensionFile, isInstalled } from './service';
 import { detectAvailableFileManager, type FileManagerType } from './detect-available';
+import { isSupportedFileManager } from './constants';
 
 type SupportedFileManager = Exclude<FileManagerType, null>;
 
@@ -21,14 +22,9 @@ function assertOrThrow({ condition, message }: AssertProps) {
 function expectedManagerFromEnv() {
   const raw = process.env.EXPECTED_FILE_MANAGER?.trim().toLowerCase();
 
-  if (!raw) {
-    return null;
-  }
+  if (!raw) return null;
 
-  const supported: SupportedFileManager[] = ['nautilus', 'nemo', 'dolphin'];
-  if (supported.includes(raw as SupportedFileManager)) {
-    return raw as SupportedFileManager;
-  }
+  if (isSupportedFileManager(raw)) return raw;
 
   throw new Error(`Invalid EXPECTED_FILE_MANAGER: ${raw}`);
 }
@@ -60,6 +56,21 @@ async function assertExecutable({ filePath }: { filePath: string }) {
   assertOrThrow({
     condition: (fileStat.mode & 0o111) !== 0,
     message: `Expected executable permissions for ${filePath}`,
+  });
+}
+
+async function assertPathRemoved({ filePath }: { filePath: string }) {
+  let exists = true;
+
+  try {
+    await access(filePath, fsConstants.F_OK);
+  } catch {
+    exists = false;
+  }
+
+  assertOrThrow({
+    condition: !exists,
+    message: `Expected file to be removed: ${filePath}`,
   });
 }
 
@@ -127,18 +138,7 @@ async function run() {
   });
 
   for (const filePath of expectedPaths) {
-    let exists = true;
-
-    try {
-      await access(filePath, fsConstants.F_OK);
-    } catch {
-      exists = false;
-    }
-
-    assertOrThrow({
-      condition: !exists,
-      message: `Expected file to be removed: ${filePath}`,
-    });
+    await assertPathRemoved({ filePath });
   }
 
   console.log(`File manager extension smoke passed for: ${manager}`);

--- a/src/backend/features/file-manager-extension/file-manager-extension-smoke.ts
+++ b/src/backend/features/file-manager-extension/file-manager-extension-smoke.ts
@@ -1,0 +1,151 @@
+import { access, readFile, stat } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { copyExtensionFile, deleteExtensionFile, isInstalled } from './service';
+import { detectAvailableFileManager, type FileManagerType } from './detect-available';
+
+type SupportedFileManager = Exclude<FileManagerType, null>;
+
+type AssertProps = {
+  condition: boolean;
+  message: string;
+};
+
+function assertOrThrow({ condition, message }: AssertProps) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function expectedManagerFromEnv() {
+  const raw = process.env.EXPECTED_FILE_MANAGER?.trim().toLowerCase();
+
+  if (!raw) {
+    return null;
+  }
+
+  const supported: SupportedFileManager[] = ['nautilus', 'nemo', 'dolphin'];
+  if (supported.includes(raw as SupportedFileManager)) {
+    return raw as SupportedFileManager;
+  }
+
+  throw new Error(`Invalid EXPECTED_FILE_MANAGER: ${raw}`);
+}
+
+function getExpectedPaths({ manager }: { manager: SupportedFileManager }) {
+  const home = homedir();
+
+  if (manager === 'nautilus') {
+    return [join(home, '.local/share/nautilus-python/extensions/internxt-virtual-drive.py')];
+  }
+
+  if (manager === 'nemo') {
+    return [join(home, '.local/share/nemo-python/extensions/internxt-virtual-drive.py')];
+  }
+
+  return [
+    join(home, '.local/share/kio/servicemenus/internxt-virtual-drive.desktop'),
+    join(home, '.local/share/kservices5/ServiceMenus/internxt-virtual-drive.desktop'),
+    join(home, '.local/share/internxt-dolphin-extension/internxt-dolphin-actions.sh'),
+  ];
+}
+
+async function assertPathExists({ filePath }: { filePath: string }) {
+  await access(filePath, fsConstants.F_OK);
+}
+
+async function assertExecutable({ filePath }: { filePath: string }) {
+  const fileStat = await stat(filePath);
+  assertOrThrow({
+    condition: (fileStat.mode & 0o111) !== 0,
+    message: `Expected executable permissions for ${filePath}`,
+  });
+}
+
+async function assertNoHomeTemplateToken({ filePath }: { filePath: string }) {
+  const content = await readFile(filePath, 'utf8');
+  assertOrThrow({
+    condition: !content.includes('{{HOME}}'),
+    message: `Template token {{HOME}} was not replaced in ${filePath}`,
+  });
+}
+
+async function run() {
+  const detected = await detectAvailableFileManager();
+  assertOrThrow({
+    condition: detected !== null,
+    message: 'No supported file manager detected in smoke environment',
+  });
+
+  const expectedFromEnv = expectedManagerFromEnv();
+  if (expectedFromEnv) {
+    assertOrThrow({
+      condition: detected === expectedFromEnv,
+      message: `Detected ${detected} but expected ${expectedFromEnv}`,
+    });
+  }
+
+  const manager = detected as SupportedFileManager;
+  const expectedPaths = getExpectedPaths({ manager });
+
+  await deleteExtensionFile();
+
+  const installedBefore = await isInstalled();
+  assertOrThrow({
+    condition: !installedBefore,
+    message: 'Extension should not be installed after pre-cleanup',
+  });
+
+  await copyExtensionFile();
+
+  const installedAfterCopy = await isInstalled();
+  assertOrThrow({
+    condition: installedAfterCopy,
+    message: 'Extension should be installed after copyExtensionFile',
+  });
+
+  for (const filePath of expectedPaths) {
+    await assertPathExists({ filePath });
+  }
+
+  if (manager === 'dolphin') {
+    await assertNoHomeTemplateToken({ filePath: expectedPaths[0] });
+    await assertNoHomeTemplateToken({ filePath: expectedPaths[1] });
+
+    for (const filePath of expectedPaths) {
+      await assertExecutable({ filePath });
+    }
+  }
+
+  await deleteExtensionFile();
+
+  const installedAfterDelete = await isInstalled();
+  assertOrThrow({
+    condition: !installedAfterDelete,
+    message: 'Extension should not be installed after deleteExtensionFile',
+  });
+
+  for (const filePath of expectedPaths) {
+    let exists = true;
+
+    try {
+      await access(filePath, fsConstants.F_OK);
+    } catch {
+      exists = false;
+    }
+
+    assertOrThrow({
+      condition: !exists,
+      message: `Expected file to be removed: ${filePath}`,
+    });
+  }
+
+  console.log(`File manager extension smoke passed for: ${manager}`);
+}
+
+run().catch((error: unknown) => {
+  console.error('File manager extension smoke failed');
+  console.error(error);
+  process.exit(1);
+});

--- a/src/backend/features/file-manager-extension/file-manager-extension-smoke.ts
+++ b/src/backend/features/file-manager-extension/file-manager-extension-smoke.ts
@@ -141,11 +141,14 @@ async function run() {
     await assertPathRemoved({ filePath });
   }
 
+  // eslint-disable-next-line no-console
   console.log(`File manager extension smoke passed for: ${manager}`);
 }
 
 run().catch((error: unknown) => {
+  // eslint-disable-next-line no-console
   console.error('File manager extension smoke failed');
+  // eslint-disable-next-line no-console
   console.error(error);
   process.exit(1);
 });

--- a/src/backend/features/file-manager-extension/file-manager-extension-smoke.ts
+++ b/src/backend/features/file-manager-extension/file-manager-extension-smoke.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { access, readFile, stat } from 'node:fs/promises';
 import { constants as fsConstants } from 'node:fs';
 import { homedir } from 'node:os';
@@ -141,14 +142,11 @@ async function run() {
     await assertPathRemoved({ filePath });
   }
 
-  // eslint-disable-next-line no-console
   console.log(`File manager extension smoke passed for: ${manager}`);
 }
 
 run().catch((error: unknown) => {
-  // eslint-disable-next-line no-console
   console.error('File manager extension smoke failed');
-  // eslint-disable-next-line no-console
   console.error(error);
   process.exit(1);
 });


### PR DESCRIPTION
## What is Changed / Added
----
- Added a new PR smoke-test workflow to validate file manager extension installation in a matrix of `nautilus`, `nemo`, and `dolphin` on Ubuntu containers:
  - `.github/workflows/file-manager-extension-smoke.yml`
- Added a dedicated smoke test script for file manager extension lifecycle checks:
  - `src/backend/features/file-manager-extension/file-manager-extension-smoke.ts`
- Added a new npm command to run the smoke test locally and in CI:
  - `smoke:file-manager-extension` in `package.json`
- Updated documentation with Linux prerequisites/setup notes:
  - `README.md`

## Why
- We recently expanded support to multiple file managers, so we need automated protection to quickly detect installation regressions.
- This smoke suite provides the practical "80% coverage" by validating:
  - file manager detection,
  - extension install/uninstall flow,
  - expected asset paths per manager,
  - Dolphin template replacement (`{{HOME}}`) and executable permissions.
- The approach is lightweight and CI-friendly, giving faster feedback in pull requests without introducing heavier GUI-level end-to-end complexity.