### PR TITLE
feat: disable remote notifications by default and log warning

### DIFF
--- a/src/apps/main/realtime.ts
+++ b/src/apps/main/realtime.ts
@@ -14,6 +14,8 @@ type XHRRequest = {
 
 let socket: Socket | undefined;
 
+const remoteNotificationsEnabled = false;
+
 export type EventPayload = {
   eventName?: string;
   id?: number;
@@ -32,6 +34,15 @@ function stopRemoteNotifications() {
 
 function cleanAndStartRemoteNotifications() {
   stopRemoteNotifications();
+
+  if (!remoteNotificationsEnabled) {
+    logger.warn({
+      msg: 'Remote notifications disabled by configuration',
+      remoteNotificationsEnabled,
+    });
+    return;
+  }
+
   const { newToken } = getCredentials();
 
   socket = io(process.env.NOTIFICATIONS_URL, {


### PR DESCRIPTION
## What is Changed / Added
----
- Remote realtime notifications are now permanently disabled in the main process by hardcoding the toggle to false.
- The startup flow now exits before creating the Socket.IO connection when a user logs in.
- Existing cleanup behavior on logout is preserved, so any active socket is still closed safely.
- A warning log was kept to indicate that remote notifications are intentionally disabled.

## Why
- The remote notifications service is currently disconnected and was producing repeated connection errors in logs.
- In this desktop app context, environment-based toggles are not useful for this case.
- Hardcoding the feature as disabled removes noisy errors and prevents unnecessary reconnect attempts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to enable or disable remote notifications.

* **Bug Fixes**
  * Prevented unnecessary real-time connections when remote notifications are disabled.
  * Added a warning to clarify when remote notifications are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->